### PR TITLE
fix: convert GitHub issue and PR links to #number

### DIFF
--- a/src/main/kotlin/detection/github/GitHubExtensions.kt
+++ b/src/main/kotlin/detection/github/GitHubExtensions.kt
@@ -28,6 +28,7 @@ object GitHubExtensions {
                     .replace(Regex("""\*+([^*]+)\*+"""), "$1")
                     .replace("`", "")
                     .replace(Regex("\\[([^]]+)]\\([^)]+\\)"), "$1")
+                    .replace(Regex("https?://github.com/\\w+/\\w+/(pull|issues)/(\\d+)")) { "#${it.groupValues[2]}" }
             }
         return buildString {
             lines?.forEachIndexed { index, line ->

--- a/src/test/kotlin/GitHubTests.kt
+++ b/src/test/kotlin/GitHubTests.kt
@@ -153,5 +153,45 @@ class GitHubTests : FunSpec({
             }
             getFormattedReleaseNotes(ghRelease) shouldBe null
         }
+
+        test("pull request links are converted to their pull request number") {
+            val ghRelease: GHRelease = mockk {
+                every { body } returns "- New feature in https://github.com/user/repository/pull/1234"
+            }
+            getFormattedReleaseNotes(ghRelease) shouldBe "- New feature in #1234"
+        }
+
+        test("issue links are converted to their issue number") {
+            val ghRelease: GHRelease = mockk {
+                every { body } returns "- Issue reported in https://github.com/user/repository/issues/4321"
+            }
+            getFormattedReleaseNotes(ghRelease) shouldBe "- Issue reported in #4321"
+        }
+
+        test("multiple pull request or issue links in a string are converted to their pull request numbers") {
+            val ghRelease: GHRelease = mockk {
+                every { body } returns buildString {
+                    append("- New features in ")
+                    append("https://github.com/user/repository/issues/1234")
+                    append(" and ")
+                    append("https://github.com/user/repository/pull/4321")
+                }
+            }
+            getFormattedReleaseNotes(ghRelease) shouldBe "- New features in #1234 and #4321"
+        }
+
+        test("pull requests without a number don't get converted") {
+            val ghRelease: GHRelease = mockk {
+                every { body } returns "- https://github.com/user/repository/pull"
+            }
+            getFormattedReleaseNotes(ghRelease) shouldBe "- https://github.com/user/repository/pull"
+        }
+
+        test("issues without a number don't get converted") {
+            val ghRelease: GHRelease = mockk {
+                every { body } returns "- https://github.com/user/repository/issues"
+            }
+            getFormattedReleaseNotes(ghRelease) shouldBe "- https://github.com/user/repository/issues"
+        }
     }
 })


### PR DESCRIPTION
Replaces pull request or issue links with their issue number in release notes.

For example:
- `https://github.com/user/repository/issues/1234` becomes `#1234`
- `https://github.com/user/repository/pull/4321` becomes `#4321`