### PR TITLE
fix: create branch from upstream default branch

### DIFF
--- a/src/main/kotlin/commands/RemoveVersion.kt
+++ b/src/main/kotlin/commands/RemoveVersion.kt
@@ -59,7 +59,7 @@ class RemoveVersion : CliktCommand(name = "remove"), KoinComponent {
             if (!shouldRemoveManifest) return@runBlocking
             echo()
             val forkRepository = githubImpl.getWingetPkgsFork(this) ?: return@runBlocking
-            val ref = githubImpl.createBranchFromDefaultBranch(forkRepository, this) ?: return@runBlocking
+            val ref = githubImpl.createBranchFromUpstreamDefaultBranch(forkRepository, this) ?: return@runBlocking
             val directoryContent: MutableList<GHContent> =
                 forkRepository.getDirectoryContent(githubImpl.baseGitHubPath, ref.ref)
             val progress = progressAnimation {


### PR DESCRIPTION
This fixes an issue where commits have been made to the fork's default branch and get included in the pull request unintentionally.

This also means that branches will always be up-to-date at the time of creation.