### PR TITLE
fix: convert issue numbers from other repositories

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ version = "1.0.5"
 
 repositories {
     mavenCentral()
-    maven(uri("https://oss.sonatype.org/content/repositories/snapshots/"))
+    maven("https://oss.sonatype.org/content/repositories/snapshots/")
 }
 
 dependencies {

--- a/src/main/kotlin/detection/github/GitHubDetection.kt
+++ b/src/main/kotlin/detection/github/GitHubDetection.kt
@@ -50,7 +50,7 @@ class GitHubDetection(url: Url) : KoinComponent {
         asset?.createdAt?.toInstant()?.atOffset(ZoneOffset.UTC)?.toLocalDate()
     }.getOrNull()
     var releaseNotesUrl: Url? = release?.htmlUrl?.let { Url(it.toURI()) }
-    var releaseNotes: String? = release?.let { GitHubExtensions.getFormattedReleaseNotes(it) }
+    var releaseNotes: String? = release?.getFormattedReleaseNotes()
     var privacyUrl: Url? = runCatching {
         repository
             .getDirectoryContent("")

--- a/src/main/kotlin/detection/github/GitHubExtensions.kt
+++ b/src/main/kotlin/detection/github/GitHubExtensions.kt
@@ -2,56 +2,60 @@ package detection.github
 
 import org.kohsuke.github.GHRelease
 
-object GitHubExtensions {
-    /**
-     * Extracts formatted release notes from a given release.
-     *
-     * 1. The function first splits the release notes body into lines and cleans each line by removing dropdowns,
-     * changing all bullet points to be dashes, removing code formatted with backticks, and converting Markdown links
-     * to plaintext.
-     * 2. It then uses a buildString block to loop through each line of the release notes.
-     * 3. If the line starts with "#" and there is another bullet point within two lines of it, it is added.
-     * 4. If the line starts with "- " it is added, with each sentence being on a new line and indented.
-     * 5. Finally, either the string is returned, or null if it is blank.
-     *
-     * @param release the [GHRelease] object containing the release notes to be formatted
-     * @return A formatted string of the release notes or null if the release notes are blank
-     */
-    fun getFormattedReleaseNotes(release: GHRelease): String? {
-        val lines = release.body
-            ?.replace("<details>.*?</details>".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE)), "")
-            ?.lines()
-            ?.map { line ->
-                line.trim()
-                    .let { if (it.startsWith("* ")) it.replaceFirst("* ", "- ") else it }
-                    .replace("""~+([^~]+)~+""".toRegex(), "$1")
-                    .replace("""\*+([^*]+)\*+""".toRegex(), "$1")
-                    .replace("`", "")
-                    .replace("\\[?!\\[(.*?)]\\((.*?)\\)(?:]\\((.*?)\\))?".toRegex(), "")
-                    .replace("\\[([^]]+)]\\([^)]+\\)".toRegex(), "$1")
-                    .replace("https?://github.com/([\\w-]+)/([\\w-]+)/(pull|issues)/(\\d+)".toRegex()) {
-                        "#${it.value.substringAfterLast("/")}"
-                    }
-                    .trim()
-            }
-        return buildString {
-            lines?.forEachIndexed { index, line ->
-                when {
-                    line.startsWith("#") -> {
-                        if (
-                            lines.getOrNull(index + 1)?.startsWith("- ") == true ||
-                            lines.getOrNull(index + 2)?.startsWith("- ") == true
-                        ) {
-                            line.dropWhile { it == '#' }.trim().takeUnless { it.isBlank() }?.let { appendLine(it) }
-                        }
-                    }
-                    line.startsWith("- ") -> {
-                        appendLine(
-                            "- ${line.replace(Regex("([A-Z][a-z].*?[.:!?](?=\$| [A-Z]))"), "$1\n ").drop(2).trim()}"
-                        )
+/**
+ * Extracts formatted release notes from a given release.
+ *
+ * 1. The function first splits the release notes body into lines and cleans each line by removing dropdowns,
+ * changing all bullet points to be dashes, removing code formatted with backticks, and converting Markdown links
+ * to plaintext.
+ * 2. It then uses a buildString block to loop through each line of the release notes.
+ * 3. If the line starts with "#" and there is another bullet point within two lines of it, it is added.
+ * 4. If the line starts with "- " it is added, with each sentence being on a new line and indented.
+ * 5. Finally, either the string is returned, or null if it is blank.
+ *
+ * @receiver release the [GHRelease] object containing the release notes to be formatted
+ * @return A formatted string of the release notes or null if the release notes are blank
+ */
+fun GHRelease.getFormattedReleaseNotes(): String? {
+    val lines = body
+        ?.replace("<details>.*?</details>".toRegex(setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.IGNORE_CASE)), "")
+        ?.lines()
+        ?.map { line ->
+            line.trim()
+                .let { if (it.startsWith("* ")) it.replaceFirst("* ", "- ") else it }
+                .replace("""~+([^~]+)~+""".toRegex(), "$1")
+                .replace("""\*+([^*]+)\*+""".toRegex(), "$1")
+                .replace("`", "")
+                .replace("\\[?!\\[(.*?)]\\((.*?)\\)(?:]\\((.*?)\\))?".toRegex(), "")
+                .replace("\\[([^]]+)]\\([^)]+\\)".toRegex(), "$1")
+                .replace("https?://github.com/([\\w-]+)/([\\w-]+)/(pull|issues)/(\\d+)".toRegex()) {
+                    val urlRepository = "${it.groupValues[1]}/${it.groupValues[2]}"
+                    val issueNumber = it.groupValues[4]
+                    if (urlRepository == owner.fullName) {
+                        "#$issueNumber"
+                    } else {
+                        "$urlRepository#$issueNumber"
                     }
                 }
+                .trim()
+        }
+    return buildString {
+        lines?.forEachIndexed { index, line ->
+            when {
+                line.startsWith("#") -> {
+                    if (
+                        lines.getOrNull(index + 1)?.startsWith("- ") == true ||
+                        lines.getOrNull(index + 2)?.startsWith("- ") == true
+                    ) {
+                        line.dropWhile { it == '#' }.trim().takeUnless { it.isBlank() }?.let { appendLine(it) }
+                    }
+                }
+                line.startsWith("- ") -> {
+                    appendLine(
+                        "- ${line.replace("([A-Z][a-z].*?[.:!?](?=\$| [A-Z]))".toRegex(), "$1\n ").drop(2).trim()}"
+                    )
+                }
             }
-        }.trim().ifBlank { null }
-    }
+        }
+    }.trim().ifBlank { null }
 }

--- a/src/test/kotlin/GitHubTests.kt
+++ b/src/test/kotlin/GitHubTests.kt
@@ -1,42 +1,44 @@
-import detection.github.GitHubExtensions.getFormattedReleaseNotes
+import detection.github.getFormattedReleaseNotes
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import org.kohsuke.github.GHRelease
+import org.kohsuke.github.GHRepository
 
 class GitHubTests : FunSpec({
     context("formatted release notes tests") {
+        val repository: GHRepository = mockk {
+            every { fullName } returns "user/repository"
+        }
+        val ghRelease: GHRelease = mockk {
+            every { owner } returns repository
+        }
+
         test("format title and bullet point") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns """
+            every { ghRelease.body } returns """
                     ## Title
                     
                     - Bullet point 1
                 """.trimIndent()
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe """
+            ghRelease.getFormattedReleaseNotes() shouldBe """
                 Title
                 - Bullet point 1
             """.trimIndent()
         }
 
         test("single title returns null") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "# Title"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns "# Title"
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("asterisk bullet points are converted to dashes") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns """
+            every { ghRelease.body } returns """
                     # Title
                     * Bullet 1
                     * Bullet 2
                 """.trimIndent()
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe """
+            ghRelease.getFormattedReleaseNotes() shouldBe """
                 Title
                 - Bullet 1
                 - Bullet 2
@@ -44,75 +46,59 @@ class GitHubTests : FunSpec({
         }
 
         test("formatting on bold text is removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- **Bold**"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Bold"
+            every { ghRelease.body } returns "- **Bold**"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Bold"
         }
 
         test("formatting on code is removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- `Code here`"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Code here"
+            every { ghRelease.body } returns "- `Code here`"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Code here"
         }
 
         test("formatting on strikethrough text is removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- ~Strikethrough~ ~~~Strikethrough text 2~~~"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Strikethrough Strikethrough text 2"
+            every { ghRelease.body } returns "- ~Strikethrough~ ~~~Strikethrough text 2~~~"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Strikethrough Strikethrough text 2"
         }
 
         test("dropdowns are removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns """
+            every { ghRelease.body } returns """
                     <details>
                         <summary>Dropdown title</summary>
                     </details>
                     - Bullet point
                 """.trimIndent()
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Bullet point"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Bullet point"
         }
 
         test("titles without a bullet point within two lines aren't included") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns """
+            every { ghRelease.body } returns """
                     # Title
                     
                     
                     - Bullet point
                 """.trimIndent()
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Bullet point"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Bullet point"
         }
 
         test("headers have # removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns """
+            every { ghRelease.body } returns """
                     #### Header
                     - Bullet point
                 """.trimIndent()
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe """
+            ghRelease.getFormattedReleaseNotes() shouldBe """
                 Header
                 - Bullet point
             """.trimIndent()
         }
 
         test("markdown links are converted into plaintext") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- [Text](Link)"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Text"
+            every { ghRelease.body } returns "- [Text](Link)"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Text"
         }
 
         test("bullet points with several sentences are split onto new lines and indented") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- First sentence. Second sentence. Third sentence."
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe """
+            every { ghRelease.body } returns "- First sentence. Second sentence. Third sentence."
+            ghRelease.getFormattedReleaseNotes() shouldBe """
                 - First sentence.
                   Second sentence.
                   Third sentence.
@@ -120,106 +106,90 @@ class GitHubTests : FunSpec({
         }
 
         test("lines without a space after their bullet point are not included") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "-Sentence"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns "-Sentence"
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("null release notes return null") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns null
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns null
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("blank release notes return null") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns " ".repeat(10)
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns " ".repeat(10)
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("lines that have miscellaneous html tags are not included") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "<html> </html>"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns "<html> </html>"
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("empty bullet points are not included") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- "
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns "- "
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("images get removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- ![Alt text](image link)"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns "- ![Alt text](image link)"
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("linked images get removed") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- [![Alt text](image link)](link)"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe null
+            every { ghRelease.body } returns "- [![Alt text](image link)](link)"
+            ghRelease.getFormattedReleaseNotes() shouldBe null
         }
 
         test("pull request links are converted to their pull request number") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- New feature in https://github.com/user/repository/pull/1234"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- New feature in #1234"
+            every { ghRelease.body } returns "- New feature in https://github.com/user/repository/pull/1234"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- New feature in #1234"
         }
 
         test("issue links are converted to their issue number") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- Issue reported in https://github.com/user/repository/issues/4321"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- Issue reported in #4321"
+            every { ghRelease.body } returns "- Issue reported in https://github.com/user/repository/issues/4321"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- Issue reported in #4321"
         }
 
         test("multiple pull request or issue links in a string are converted to their issue numbers") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns buildString {
-                    append("- New features in ")
-                    append("https://github.com/user/repository/issues/1234")
-                    append(" and ")
-                    append("https://github.com/user/repository/pull/4321")
-                }
+            every { ghRelease.body } returns buildString {
+                append("- New features in ")
+                append("https://github.com/user/repository/issues/1234")
+                append(" and ")
+                append("https://github.com/user/repository/pull/4321")
             }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- New features in #1234 and #4321"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- New features in #1234 and #4321"
         }
 
         test("issues with a dash in the user or repository are converted to their issue numbers") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- https://github.com/user-name/repository-extra/issues/1234"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- #1234"
+            every { ghRelease.body } returns "- https://github.com/user-name/repository-extra/issues/1234"
+            every { repository.fullName } returns "user-name/repository-extra"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- #1234"
         }
 
         test("pull requests with a dash in the user or repository are converted to their issue numbers") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- https://github.com/user-name/repository-extra/pull/4321"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- #4321"
+            every { ghRelease.body } returns "- https://github.com/user-name/repository-extra/pull/4321"
+            every { repository.fullName } returns "user-name/repository-extra"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- #4321"
         }
 
         test("pull requests without a number don't get converted") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- https://github.com/user/repository/pull"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- https://github.com/user/repository/pull"
+            every { ghRelease.body } returns "- https://github.com/user/repository/pull"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- https://github.com/user/repository/pull"
         }
 
         test("issues without a number don't get converted") {
-            val ghRelease: GHRelease = mockk {
-                every { body } returns "- https://github.com/user/repository/issues"
-            }
-            getFormattedReleaseNotes(ghRelease) shouldBe "- https://github.com/user/repository/issues"
+            every { ghRelease.body } returns "- https://github.com/user/repository/issues"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- https://github.com/user/repository/issues"
+        }
+
+        test("issues outside the repository are converted appropriately") {
+            every { ghRelease.body } returns "- https://github.com/other-user/repository/issues/1234"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- other-user/repository#1234"
+        }
+
+        test("pull requests outside the repository are converted appropriately") {
+            every { ghRelease.body } returns "- https://github.com/user/other-repository/pull/4321"
+            ghRelease.getFormattedReleaseNotes() shouldBe "- user/other-repository#4321"
         }
     }
 })


### PR DESCRIPTION
## Description
Issues referenced in release notes that are from other repositories will now get converted appropriately.

### Example

Repository of release - `user/repository`

Issue inside repository - `https://github.com/user/repository/issues/1234`
Result - `#1234`

Issue outside repository - `https://github.com/other-user/other-repository/issues/1234`
Result- `other-user/other-repository#1234`