### PR TITLE
fix: URLs only showing as https in manifest preview

### DIFF
--- a/src/main/kotlin/commands/NewManifest.kt
+++ b/src/main/kotlin/commands/NewManifest.kt
@@ -112,7 +112,7 @@ class NewManifest : CliktCommand(name = "new"), KoinComponent {
                     releaseNotesUrl = prompt(ReleaseNotesUrl)
                     val files = createFiles()
                     files.forEach { manifest ->
-                        ManifestUtils.formattedManifestLinesFlow(manifest.second, colors).collect { echo(it) }
+                        ManifestUtils.formattedManifestLinesFlow(manifest.second, colors).collect(::echo)
                     }
                     pullRequestPrompt(packageIdentifier, packageVersion).also { manifestResultOption ->
                         when (manifestResultOption) {

--- a/src/main/kotlin/commands/QuickUpdate.kt
+++ b/src/main/kotlin/commands/QuickUpdate.kt
@@ -121,7 +121,7 @@ class QuickUpdate : CliktCommand(name = "update"), KoinComponent {
                 loopThroughInstallers(parameterUrls = urls, isCIEnvironment = isCIEnvironment)
                 val files = createFiles()
                 files.forEach { manifest ->
-                    formattedManifestLinesFlow(manifest.second, colors).collect { echo(it) }
+                    formattedManifestLinesFlow(manifest.second, colors).collect(::echo)
                 }
                 if (submit) {
                     githubImpl.commitAndPullRequest(files, currentContext.terminal)

--- a/src/main/kotlin/data/ManifestUtils.kt
+++ b/src/main/kotlin/data/ManifestUtils.kt
@@ -10,7 +10,7 @@ object ManifestUtils {
             when {
                 line.startsWith("#") -> emit(colors.green(line))
                 line.firstOrNull()?.isLetter() == true -> {
-                    val part = line.split(":")
+                    val part = line.split(":", limit = 2)
                     emit("${colors.info(part.first())}${part.getOrNull(1)?.let { ":$it" } ?: ""}")
                 }
                 line.startsWith("-") -> emit(line)


### PR DESCRIPTION
Splitting a line by `:` caused URLs to also be split, meaning only `https` would be shown.

Before:
`PublisherUrl: https://www.example.com` -> `PublisherUrl` + ` https` + `//www.example.com`

After:
`PublisherUrl: https://www.example.com` -> `PublisherUrl` + ` https://www.example.com`