### PR TITLE
fix: default locale branch name on new

### DIFF
--- a/src/main/kotlin/commands/NewManifest.kt
+++ b/src/main/kotlin/commands/NewManifest.kt
@@ -158,7 +158,7 @@ class NewManifest : CliktCommand(name = "new") {
             ),
             GitHubUtils.getDefaultLocaleManifestName(
                 identifier = packageIdentifier,
-                defaultLocale = packageVersion,
+                defaultLocale = defaultLocale,
                 previousDefaultLocale = defaultLocaleManifest?.packageLocale
             ) to DefaultLocaleManifestData.createDefaultLocaleManifest(
                 allManifestData = allManifestData,


### PR DESCRIPTION
The name for the default locale manifest when using `new` mistakenly had the package version instead of the default locale in the name.