### PR TITLE
feat: add branch cleanup command

### DIFF
--- a/src/main/kotlin/Main.kt
+++ b/src/main/kotlin/Main.kt
@@ -2,6 +2,7 @@
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.russellbanks.Komac.BuildConfig
+import commands.Cleanup
 import commands.NewManifest
 import commands.QuickUpdate
 import commands.RemoveVersion
@@ -11,7 +12,7 @@ import commands.token.Update
 
 fun main(args: Array<String>) {
     Komac()
-        .subcommands(NewManifest(), QuickUpdate(), RemoveVersion(), Token().subcommands(Update(), Remove()))
+        .subcommands(NewManifest(), QuickUpdate(), RemoveVersion(), Token().subcommands(Update(), Remove()), Cleanup())
         .versionOption(version = BuildConfig.appVersion, names = setOf("-v", "--version"))
         .main(args)
 }

--- a/src/main/kotlin/commands/Cleanup.kt
+++ b/src/main/kotlin/commands/Cleanup.kt
@@ -1,0 +1,20 @@
+package commands
+
+import com.github.ajalt.clikt.core.CliktCommand
+import data.GitHubImpl
+
+class Cleanup : CliktCommand(name = "cleanup") {
+    override fun run() {
+        val fork = GitHubImpl.getWingetPkgsFork(currentContext.terminal)
+        fork.branches.values
+            .filterNot { it.name == GitHubImpl.microsoftWinGetPkgs.defaultBranch }
+            .forEach { branch ->
+                runCatching {
+                    GitHubImpl.microsoftWinGetPkgs.queryCommits().from(branch.shA1).list().withPageSize(1).first().let {
+                        warning("Deleting ${branch.name} because it was merged in ${it.htmlUrl}")
+                        fork.getRef("heads/${branch.name}").delete()
+                    }
+                }
+            }
+    }
+}

--- a/src/main/kotlin/commands/Cleanup.kt
+++ b/src/main/kotlin/commands/Cleanup.kt
@@ -5,16 +5,33 @@ import data.GitHubImpl
 
 class Cleanup : CliktCommand(name = "cleanup") {
     override fun run() {
-        val fork = GitHubImpl.getWingetPkgsFork(currentContext.terminal)
-        fork.branches.values
+        val wingetPkgsFork = GitHubImpl.getWingetPkgsFork(currentContext.terminal)
+        var branchesDeleted = 0
+
+        wingetPkgsFork.branches.values
             .filterNot { it.name == GitHubImpl.microsoftWinGetPkgs.defaultBranch }
             .forEach { branch ->
                 runCatching {
-                    GitHubImpl.microsoftWinGetPkgs.queryCommits().from(branch.shA1).list().withPageSize(1).first().let {
-                        warning("Deleting ${branch.name} because it was merged in ${it.htmlUrl}")
-                        fork.getRef("heads/${branch.name}").delete()
+                    val commit = GitHubImpl.microsoftWinGetPkgs
+                        .queryCommits()
+                        .from(branch.shA1)
+                        .list()
+                        .withPageSize(1)
+                        .first()
+
+                    commit.let {
+                        val branchName = branch.name
+                        warning("Deleting $branchName because it was merged in ${it.htmlUrl}")
+                        wingetPkgsFork.getRef("heads/$branchName").delete()
+                        branchesDeleted++
                     }
                 }
             }
+
+        if (branchesDeleted == 0) {
+            echo("No branches were found that could be deleted")
+        } else {
+            success("$branchesDeleted branches were deleted")
+        }
     }
 }


### PR DESCRIPTION
Automatically deletes branches in winget-pkgs fork that have had a commit associated with them.

```pwsh
komac cleanup
```

![WindowsTerminal_5HD7DoGycf](https://user-images.githubusercontent.com/74878137/236578804-3d4b80d1-8ee7-4d99-a598-6daaf88e1819.png)
