### PR TITLE
fix: incorrect full description indentation

### DIFF
--- a/src/main/kotlin/data/DefaultLocaleManifestData.kt
+++ b/src/main/kotlin/data/DefaultLocaleManifestData.kt
@@ -40,8 +40,9 @@ object DefaultLocaleManifestData {
                 ?: previousDefaultLocaleData?.shortDescription
                 ?: gitHubDetection?.shortDescription.orEmpty(),
             description = (description ?: previousDefaultLocaleData?.description)
-                ?.replace(Regex("([A-Z][a-z].*?[.:!?](?=\$| [A-Z]))"), "$1\n")
-                ?.trim()
+                ?.replace(Regex("([A-Z][a-z].*?[.:!?]) ?(?=\$|[A-Z])"), "$1\n")
+                ?.lines()
+                ?.joinToString("\n") { it.trimStart() }
                 ?.ifBlank { null },
             moniker = (moniker ?: previousDefaultLocaleData?.moniker)?.ifBlank { null },
             tags = (tags ?: previousDefaultLocaleData?.tags)?.take(Tags.validationRules.maxItems)?.ifEmpty { null },


### PR DESCRIPTION
- Changes the sentence Regex to consume the space after each line
- Trims the start of each full description line for manifests that were already created with this issue or have incorrect indentation anyway

Before:
```
Sentence one.
 Sentence two
^ note space
```
After:
```
Sentence one.
Sentence two
```