### PR TITLE
fix: remove MinimumOSVersion using previous manifest value

### DIFF
--- a/src/main/kotlin/data/InstallerManifestData.kt
+++ b/src/main/kotlin/data/InstallerManifestData.kt
@@ -117,8 +117,7 @@ object InstallerManifestData {
             platform = installers.getDistinctOrNull(InstallerManifest.Installer::platform)
                 ?: previousInstallerManifest?.platform,
             minimumOSVersion = installers.getDistinctOrNull(InstallerManifest.Installer::minimumOSVersion)
-                ?.ifBlank { null }
-                ?: previousInstallerManifest?.minimumOSVersion,
+                ?.ifBlank { null },
             installerType = installers.getDistinctOrNull(InstallerManifest.Installer::installerType)
                 ?: previousInstallerManifest?.installerType,
             nestedInstallerType = installers.getDistinctOrNull(InstallerManifest.Installer::nestedInstallerType)


### PR DESCRIPTION
Lots of manifests have `MinimumOSVersion: 10.0.0.0` unnecessarily. Komac should detect all scenarios when this value is needed (MSIX's), so we do not need to use the previous value.