### PR TITLE
fix: full description not trimming in YAML

### DIFF
--- a/src/main/kotlin/data/DefaultLocaleManifestData.kt
+++ b/src/main/kotlin/data/DefaultLocaleManifestData.kt
@@ -43,6 +43,7 @@ object DefaultLocaleManifestData {
                 ?.replace(Regex("([A-Z][a-z].*?[.:!?]) ?(?=\$|[A-Z])"), "$1\n")
                 ?.lines()
                 ?.joinToString("\n") { it.trim() }
+                ?.trim()
                 ?.ifBlank { null },
             moniker = (moniker ?: previousDefaultLocaleData?.moniker)?.ifBlank { null },
             tags = (tags ?: previousDefaultLocaleData?.tags)?.take(Tags.validationRules.maxItems)?.ifEmpty { null },


### PR DESCRIPTION
Explicitly adding .trim() adds the `|-` in the resulting YAML. This was removed in #187 as each line gets trimmed anyway, with the unintentional effect of removing the `|-`.