### PR TITLE
fix: set display version in manifest as package version

### DIFF
--- a/src/main/kotlin/data/InstallerManifestData.kt
+++ b/src/main/kotlin/data/InstallerManifestData.kt
@@ -132,7 +132,7 @@ object InstallerManifestData {
                 null
             },
             publisher = if (arpPublisher != publisher) arpPublisher else null,
-            displayVersion = if (displayVersion != packageVersion) displayVersion else null,
+            displayVersion = if (displayVersion != packageVersion) packageVersion else null,
             upgradeCode = msi?.upgradeCode ?: upgradeCode
         )
     }

--- a/src/main/kotlin/data/InstallerManifestData.kt
+++ b/src/main/kotlin/data/InstallerManifestData.kt
@@ -132,7 +132,7 @@ object InstallerManifestData {
                 null
             },
             publisher = if (arpPublisher != publisher) arpPublisher else null,
-            displayVersion = if (displayVersion != packageVersion) packageVersion else null,
+            displayVersion = packageVersion,
             upgradeCode = msi?.upgradeCode ?: upgradeCode
         )
     }


### PR DESCRIPTION
# Problem

I encountered [error](https://github.com/microsoft/winget-pkgs/pull/112570/checks?check_run_id=15166049103) when upgrading Arduino IDE package. The error says:
`Manifest Error: DisplayVersion declared in the manifest has overlap with existing DisplayVersion range in the index.Existing DisplayVersion range in index :  [ [2.1.0, 2.1.0]]`

After I checked `Komac`'s source code, I found out that the `displayVersion` refers to MSI file if included. That shouldn't be a problem. However, one edge case is that the data contained in MSI file is wrong.

# Steps to Reproduce

Since I encountered this bug with Arduino IDE installer, the package and URL will be of Arduino IDE.
1) Run this command: `komac update --id ArduinoSA.IDE.stable --version 2.1.1 --urls https://github.com/arduino/arduino-ide/releases/download/2.1.1/arduino-ide_2.1.1_Windows_64bit.msi`
    a) This command must be run before [this PR](https://github.com/microsoft/winget-pkgs/pull/112570) is merged.
2) Save the manifest.
3) Search for `DisplayVersion` in the `*.installer.yaml` file. Notice that the version is not the same as version sent in command line.

# My Solution

My solution is to set `displayVersion` as package version, regardless of whether the installer is MSI file or not.