### PR TITLE
Publish SHA256 checksums of assets while releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,6 +151,14 @@ jobs:
             /DArchitecture=${{ matrix.platform.arch }} `
             /F$("${{ steps.rename_binary.outputs.name }}".Replace("Portable", "Setup").TrimEnd(".exe"))
 
+      - name: Compute SHA256 checksum
+        shell: pwsh
+        run: |
+          Get-Item -ErrorAction SilentlyContinue -Path "assets/Output/*","target/${{ matrix.platform.target }}/release/*","target/${{ matrix.platform.target }}/debian/*" -Include "KomacPortable*","KomacSetup*","komac*.deb" | ForEach-Object {
+            $FileHash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
+            New-Item -Force -ItemType File -Path $_.DirectoryName -Name "$($_.Name).sha256" -Value "$FileHash *$($_.Name)`n"
+          }
+
       - name: Set Release variables
         id: set_release_vars
         shell: pwsh
@@ -176,6 +184,7 @@ jobs:
           generate_release_notes: ${{ steps.set_release_vars.outputs.generate_release_notes }}
           files: |
             target/${{ matrix.platform.target }}/release/${{ steps.rename_binary.outputs.name }}
-            target/${{ matrix.platform.target }}/debian/*.deb
-            ${{ steps.rename_binary.outputs.name }}.tar.gz
+            target/${{ matrix.platform.target }}/release/${{ steps.rename_binary.outputs.name }}.sha256
+            target/${{ matrix.platform.target }}/debian/*.{deb,sha256}
+            ${{ steps.rename_binary.outputs.name }}.{tar.gz,sha256}
             assets/Output/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,8 @@ jobs:
           files: |
             target/${{ matrix.platform.target }}/release/${{ steps.rename_binary.outputs.name }}
             target/${{ matrix.platform.target }}/release/${{ steps.rename_binary.outputs.name }}.sha256
-            target/${{ matrix.platform.target }}/debian/*.{deb,sha256}
-            ${{ steps.rename_binary.outputs.name }}.{tar.gz,sha256}
+            target/${{ matrix.platform.target }}/debian/*.deb
+            target/${{ matrix.platform.target }}/debian/*.sha256
+            ${{ steps.rename_binary.outputs.name }}.tar.gz
+            ${{ steps.rename_binary.outputs.name }}.tar.gz.sha256
             assets/Output/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Compute SHA256 checksum
         shell: pwsh
         run: |
-          Get-Item -ErrorAction SilentlyContinue -Path "assets/Output/*","target/${{ matrix.platform.target }}/release/*","target/${{ matrix.platform.target }}/debian/*" -Include "KomacPortable*","KomacSetup*","komac*.deb" | ForEach-Object {
+          Get-Item -ErrorAction SilentlyContinue -Path "${{ steps.rename_binary.outputs.name }}.tar.gz","assets/Output/*","target/${{ matrix.platform.target }}/release/*","target/${{ matrix.platform.target }}/debian/*" -Include "KomacPortable*","KomacSetup*","komac*.deb" | ForEach-Object {
             $FileHash = (Get-FileHash -Path $_.FullName -Algorithm SHA256).Hash.ToLower()
             New-Item -Force -ItemType File -Path $_.DirectoryName -Name "$($_.Name).sha256" -Value "$FileHash *$($_.Name)`n"
           }


### PR DESCRIPTION
When downloading assets for a release, it's helpful to be able to verify that the data has no corruption or changes. It is common for many packages to provide a `checksums.txt` file and/or a `.sha256` file for each version resource for this purpose. With this PR, I'm computing the SHA256 checksums of each binary and I'm uploading the respective files as part of the GitHub release.