### PR TITLE
docs(readme): Add link to run-komac action

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ jobs:
 ### Alternative actions 🔄
 
 - Run Komac manually: [michidk/run-komac](https://github.com/michidk/run-komac)
+- Automate releases for external repositories: [michidk/winget-updater](https://github.com/michidk/winget-updater)
 
 ## How can I support Komac? ❤️
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ jobs:
           # installers-regex: '\.exe$' # Only .exe files
 ```
 
-If you just want to run Komac manually, you can use the [michidk/run-komac](https://github.com/michidk/run-komac/) action.
+### Alternative actions 🔄
+
+- Run Komac manually: [michidk/run-komac](https://github.com/michidk/run-komac)
 
 ## How can I support Komac? ❤️
 

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ jobs:
           # installers-regex: '\.exe$' # Only .exe files
 ```
 
+If you just want to run Komac manually, you can use the [michidk/run-komac](https://github.com/michidk/run-komac/) action.
+
 ## How can I support Komac? ❤️
 
 - 🤝 Sponsor this project through [GitHub Sponsors](https://github.com/sponsors/russellbanks)


### PR DESCRIPTION
Adds a link to my [run-komac](https://github.com/michidk/run-komac/) action.

This action installs the specified version into the GHA job.