### PR TITLE
Add Docker Build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github
+.gitattributes
+.gitigore
+*.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,18 @@ Contributions are what make the open source community such an amazing place to l
 3. Commit your Changes (`git commit -m 'Add some feature'`)
 4. Push to the Branch (`git push origin feat/new-feature`)
 5. Open a Pull Request
+
+### Testing your changes
+
+Using Docker is the easiest way to to test your code before submitting a pull request. 
+
+> [!NOTE]
+> When using the Docker container on Windows, the WSL engine does not support the default collection for keys or tokens. This means that when testing inside the container GitHub tokens will not be stored, even when `komac token update` is used.
+> 
+> This is a [known issue](https://github.com/hwchen/keyring-rs/blob/47c8daf3e6178a2282ae3e8670d1ea7fa736b8cb/src/secret_service.rs#L73-L77) which is documented in the keyring crate.
+
+1. Ensure you have docker installed and the docker engine is running.
+2. Run `docker build ./ --tag komac_dev:latest`.
+3. Wait for the build to complete.
+4. Start the container using `docker run -it komac_dev bash`.
+5. Test out any commands. Use the `exit` command to quit the container

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,8 @@ Using Docker is the easiest way to to test your code before submitting a pull re
 > When using the Docker container on Windows, the WSL engine does not support the default collection for keys or tokens. This means that when testing inside the container GitHub tokens will not be stored, even when `komac token update` is used.
 > 
 > This is a [known issue](https://github.com/hwchen/keyring-rs/blob/47c8daf3e6178a2282ae3e8670d1ea7fa736b8cb/src/secret_service.rs#L73-L77) which is documented in the keyring crate.
+>
+> As a workaround, you can set the `GITHUB_TOKEN` environment variable from within the container, in the `docker run` command, or in the Dockerfile itself
 
 1. Ensure you have docker installed and the docker engine is running.
 2. Run `docker build ./ --tag komac_dev:latest`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM rust:1.80-slim as build
+
+# Copy source code into the build container
+WORKDIR /usr/src 
+COPY ./ /usr/src
+
+# Install apt packages required for building the package dependencies
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --no-install-suggests \
+    libssl-dev \
+    perl \
+    make
+
+# Build Komac from the source code
+# RUN cargo build --release --locked
+RUN cargo install komac --locked
+
+# Create a new container for
+FROM debian:bookworm-slim as release 
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --no-install-suggests \
+    ca-certificates
+COPY --from=build /usr/local/cargo/bin/komac /usr/local/bin/
+# COPY --from=build /usr/src/target/release/komac /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,18 +7,22 @@ COPY ./ /usr/src
 # Install apt packages required for building the package dependencies
 RUN apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
-    libssl-dev \
-    perl \
-    make
+      libssl-dev \
+      perl \
+      make
 
 # Build Komac from the source code
-# RUN cargo build --release --locked
-RUN cargo install komac --locked
+RUN cargo build --release
 
 # Create a new container for
 FROM debian:bookworm-slim as release 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends --no-install-suggests \
-    ca-certificates
-COPY --from=build /usr/local/cargo/bin/komac /usr/local/bin/
-# COPY --from=build /usr/src/target/release/komac /usr/local/bin/
+      ca-certificates \
+ && rm -rf  \
+      /var/lib/apt/lists/* \
+      /tmp/* \
+      /var/tmp/*
+
+COPY --from=build /usr/src/target/release/komac /usr/local/bin/
+WORKDIR /root


### PR DESCRIPTION
Not all contributors will want to install the Rust toolchain to build, test, and contribute a fix or a feature.  Additionally, with Komac being able to run on GitHub runners, it is imperative to test Linux compatibility of new features and functionality. Without setting up a Linux VM, it can be difficult to test these changes.

This PR adds a dockerfile and related documentation on how to use it. This will allow contributors to build and test Komac without having the Rust toolchain installed on their machine, and will make it easier to test Linux behaviors without requiring the setup or maintenance of a full VM.