### PR TITLE
Add `replace` update option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1192,6 +1192,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2469,6 +2480,7 @@ dependencies = [
  "crossterm 0.28.1",
  "cynic",
  "cynic-codegen",
+ "derive-new",
  "derive_more",
  "encoding_rs",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ const_format = { version = "0.2.34", features = ["derive"] }
 crc32fast = "1.4.2"
 crossterm = "0.28.1"
 cynic = { version = "3.9.1", features = ["http-reqwest"] }
+derive-new = "0.7.0"
 derive_more = { version = "2.0.1", features = ["as_ref", "constructor", "debug", "deref", "deref_mut", "display", "from_str", "into_iterator"] }
 encoding_rs = "0.8.35"
 flate2 = "1.0.35"

--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -6,7 +6,7 @@ use std::num::{NonZeroU32, NonZeroU8};
 use anstream::println;
 use camino::Utf8PathBuf;
 use clap::Parser;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{bail, Result};
 use indicatif::ProgressBar;
 use owo_colors::OwoColorize;
 use reqwest::Client;
@@ -111,22 +111,21 @@ impl UpdateVersion {
             self.package_identifier
         );
 
-        let mut replace = match self.replace.clone() {
-            Some(version) if version.to_string() == "latest" => Some(latest_version.clone()),
-            other => other,
-        };
+        let replace_version = self
+            .replace
+            .as_ref()
+            .map(|version| {
+                version
+                    .is_latest()
+                    .then_some(latest_version)
+                    .unwrap_or(version)
+            })
+            .filter(|&version| version != &self.package_version);
 
-        if let Some(ref replace_version) = replace {
-            if !versions.iter().any(|v| v == replace_version) {
-                return Err(color_eyre::eyre::eyre!(
-                    "Replacement version '{}' not found.",
-                    replace_version
-                ));
+        if let Some(version) = replace_version {
+            if !versions.contains(version) {
+                bail!("Replacement version {version} does not exist in {WINGET_PKGS_FULL_NAME}")
             }
-        }
-
-        if replace.as_ref() == Some(&self.package_version) {
-            replace = None;
         }
 
         if let Some(pull_request) = existing_pr.await? {
@@ -272,7 +271,7 @@ impl UpdateVersion {
             .version(&self.package_version)
             .versions(&versions)
             .changes(changes)
-            .maybe_replace(replace)
+            .maybe_replace_version(replace_version)
             .maybe_issue_resolves(self.resolves)
             .maybe_created_with(self.created_with)
             .maybe_created_with_url(self.created_with_url)

--- a/src/github/graphql/create_commit.rs
+++ b/src/github/graphql/create_commit.rs
@@ -1,5 +1,7 @@
 use crate::github::graphql::github_schema::github_schema as schema;
 use crate::github::graphql::types::{Base64String, GitObjectId};
+use derive_new::new;
+use std::borrow::Cow;
 use url::Url;
 
 #[derive(cynic::QueryVariables)]
@@ -46,16 +48,18 @@ pub struct FileChanges<'a> {
 }
 
 /// <https://docs.github.com/graphql/reference/input-objects#filedeletion>
-#[derive(cynic::InputObject)]
-pub struct FileDeletion<'a> {
-    pub path: &'a str,
+#[derive(cynic::InputObject, new)]
+pub struct FileDeletion<'path> {
+    #[new(into)]
+    pub path: Cow<'path, str>,
 }
 
 /// <https://docs.github.com/graphql/reference/input-objects#fileaddition>
-#[derive(cynic::InputObject)]
-pub struct FileAddition<'a> {
+#[derive(cynic::InputObject, new)]
+pub struct FileAddition<'path> {
     pub contents: Base64String,
-    pub path: &'a str,
+    #[new(into)]
+    pub path: Cow<'path, str>,
 }
 
 /// <https://docs.github.com/graphql/reference/input-objects#committablebranch>

--- a/src/types/version.rs
+++ b/src/types/version.rs
@@ -57,6 +57,12 @@ impl Version {
     pub fn as_str(&self) -> &str {
         &self.raw
     }
+
+    pub fn is_latest(&self) -> bool {
+        const LATEST: &str = "latest";
+
+        self.raw.eq_ignore_ascii_case(LATEST)
+    }
 }
 
 impl PartialEq for Version {


### PR DESCRIPTION
Adds a update option to replace an existing package version. Similar to WingetCreate's [`--replace`](https://github.com/microsoft/winget-create/blob/main/doc/update.md#arguments) option.

Example PR: https://github.com/microsoft/winget-pkgs/pull/225515