### PR TITLE
Skip release notes URL when notes are empty

### DIFF
--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -190,9 +190,13 @@ impl LocaleExt for LocaleManifest {
     ) {
         self.package_version.clone_from(package_version);
         self.release_notes_url = release_notes_url.cloned().or_else(|| {
-            github_values
-                .as_ref()
-                .and_then(|values| values.release_notes_url.clone())
+            github_values.as_ref().and_then(|values| {
+                if values.release_notes.is_some() {
+                    values.release_notes_url.clone()
+                } else {
+                    None
+                }
+            })
         });
         self.manifest_type = Self::TYPE;
         self.manifest_version = ManifestVersion::default();
@@ -243,9 +247,13 @@ impl LocaleExt for DefaultLocaleManifest {
             .as_mut()
             .and_then(|values| values.release_notes.take());
         self.release_notes_url = release_notes_url.cloned().or_else(|| {
-            github_values
-                .as_mut()
-                .and_then(|values| values.release_notes_url.take())
+            github_values.as_mut().and_then(|values| {
+                if values.release_notes.is_some() {
+                    values.release_notes_url.take()
+                } else {
+                    None
+                }
+            })
         });
         self.manifest_type = Self::TYPE;
         self.manifest_version = ManifestVersion::default();


### PR DESCRIPTION
Fixes an issue where Komac adds a `ReleaseNotesUrl` to a Github release page with no release notes

```
komac update mesonbuild.meson -v 1.7.1 -u https://github.com/mesonbuild/meson/releases/download/1.7.1/meson-1.7.1-64.msi --dry-run
```
Before:
```yaml
Tags:
- build-system
- foss
- meson
- ninja
- open-source
ReleaseNotesUrl: https://github.com/mesonbuild/meson/releases/tag/1.7.1
Documentations:
- DocumentLabel: Wiki
  DocumentUrl: https://github.com/mesonbuild/meson/wiki
```
After:
```yaml
Tags:
- build-system
- foss
- meson
- ninja
- open-source
Documentations:
- DocumentLabel: Wiki
  DocumentUrl: https://github.com/mesonbuild/meson/wiki
```