### PR TITLE
Add ability to override detected architecture

### DIFF
--- a/src/commands/new_version.rs
+++ b/src/commands/new_version.rs
@@ -43,7 +43,7 @@ use crate::{
         github_client::{GITHUB_HOST, GitHub, WINGET_PKGS_FULL_NAME},
         utils::{PackagePath, pull_request::pr_changes},
     },
-    manifests::Manifests,
+    manifests::{Manifests, Url},
     prompts::{
         check_prompt, handle_inquire_error,
         list::list_prompt,
@@ -66,7 +66,7 @@ pub struct NewVersion {
 
     /// The list of package installers
     #[arg(short, long, num_args = 1.., value_hint = clap::ValueHint::Url)]
-    urls: Vec<DecodedUrl>,
+    urls: Vec<Url>,
 
     #[arg(long)]
     package_locale: Option<LanguageTag>,
@@ -193,8 +193,8 @@ impl NewVersion {
         if urls.is_empty() {
             while urls.len() < 1024 {
                 let message = format!("{} Installer URL", Ordinal(urls.len() + 1));
-                let url_prompt = CustomType::<DecodedUrl>::new(&message)
-                    .with_error_message("Please enter a valid URL");
+                let url_prompt =
+                    CustomType::new(&message).with_error_message("Please enter a valid URL");
                 let installer_url = if urls.len() + 1 == 1 {
                     Some(url_prompt.prompt().map_err(handle_inquire_error)?)
                 } else {
@@ -219,7 +219,7 @@ impl NewVersion {
                 .cloned();
             async move {
                 github_url
-                    .map(|url| github.get_all_values_from_url(url))
+                    .map(|url| github.get_all_values_from_url(url.into_inner()))
                     .unwrap_or_default()
                     .await
             }

--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -33,6 +33,7 @@ use crate::{
         utils::{PackagePath, pull_request::pr_changes},
     },
     installers::zip::Zip,
+    manifests::Url,
     match_installers::match_installers,
     terminal::Hyperlinkable,
     traits::{LocaleExt, path::NormalizePath},
@@ -51,7 +52,7 @@ pub struct UpdateVersion {
 
     /// The list of package installers
     #[arg(short, long, num_args = 1.., required = true, value_hint = clap::ValueHint::Url)]
-    urls: Vec<DecodedUrl>,
+    urls: Vec<Url>,
 
     /// Number of installers to download at the same time
     #[arg(long, default_value_t = NonZeroUsize::new(num_cpus::get()).unwrap())]
@@ -175,7 +176,7 @@ impl UpdateVersion {
                 .cloned();
             async move {
                 github_url
-                    .map(|url| github.get_all_values_from_url(url))
+                    .map(|url| github.get_all_values_from_url(url.into_inner()))
                     .unwrap_or_default()
                     .await
             }

--- a/src/download/downloader.rs
+++ b/src/download/downloader.rs
@@ -1,5 +1,4 @@
 use std::num::NonZeroUsize;
-use std::str::FromStr;
 
 use chrono::DateTime;
 use color_eyre::{
@@ -19,7 +18,7 @@ use tokio::{
     sync::mpsc,
     try_join,
 };
-use winget_types::{Sha256String, installer::Architecture, url::DecodedUrl};
+use winget_types::Sha256String;
 
 use super::{Download, DownloadedFile};
 
@@ -75,14 +74,6 @@ impl Downloader {
         download.convert_to_github_versioned().await?;
 
         download.upgrade_to_https(client).await;
-
-        let mut override_arch: Option<Architecture> = None;
-        if let Some((base, arch)) = download.url.as_str().rsplit_once('|') {
-            if let Ok(parsed) = arch.parse::<Architecture>() {
-                override_arch = Some(parsed);
-                download.url = DecodedUrl::from_str(base).unwrap();
-            }
-        }
 
         let res = client.get(download.url.as_str()).send().await?;
 
@@ -163,7 +154,6 @@ impl Downloader {
             url: download.url,
             mmap: unsafe { Mmap::map(&temp_file) }?,
             file: temp_file,
-            override_arch,
             sha_256: Sha256String::from_digest(&sha_256),
             file_name,
             last_modified,

--- a/src/download/downloader.rs
+++ b/src/download/downloader.rs
@@ -1,4 +1,5 @@
 use std::num::NonZeroUsize;
+use std::str::FromStr;
 
 use chrono::DateTime;
 use color_eyre::{
@@ -18,7 +19,7 @@ use tokio::{
     sync::mpsc,
     try_join,
 };
-use winget_types::Sha256String;
+use winget_types::{Sha256String, installer::Architecture, url::DecodedUrl};
 
 use super::{Download, DownloadedFile};
 
@@ -74,6 +75,14 @@ impl Downloader {
         download.convert_to_github_versioned().await?;
 
         download.upgrade_to_https(client).await;
+
+        let mut override_arch: Option<Architecture> = None;
+        if let Some((base, arch)) = download.url.as_str().rsplit_once('|') {
+            if let Ok(parsed) = arch.parse::<Architecture>() {
+                override_arch = Some(parsed);
+                download.url = DecodedUrl::from_str(base).unwrap();
+            }
+        }
 
         let res = client.get(download.url.as_str()).send().await?;
 
@@ -154,6 +163,7 @@ impl Downloader {
             url: download.url,
             mmap: unsafe { Mmap::map(&temp_file) }?,
             file: temp_file,
+            override_arch,
             sha_256: Sha256String::from_digest(&sha_256),
             file_name,
             last_modified,

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -2,7 +2,9 @@ use std::fs::File;
 
 use chrono::NaiveDate;
 use memmap2::Mmap;
-use winget_types::{Sha256String, installer::Architecture, url::DecodedUrl};
+use winget_types::Sha256String;
+
+use crate::manifests::Url;
 
 pub struct DownloadedFile {
     // As the downloaded file is a temporary file, it's stored here so that the reference stays
@@ -10,9 +12,8 @@ pub struct DownloadedFile {
     // file to remain present.
     #[expect(dead_code)]
     pub file: File,
-    pub url: DecodedUrl,
+    pub url: Url,
     pub mmap: Mmap,
-    pub override_arch: Option<Architecture>,
     pub sha_256: Sha256String,
     pub file_name: String,
     pub last_modified: Option<NaiveDate>,

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 
 use chrono::NaiveDate;
 use memmap2::Mmap;
-use winget_types::{Sha256String, url::DecodedUrl};
+use winget_types::{Sha256String, installer::Architecture, url::DecodedUrl};
 
 pub struct DownloadedFile {
     // As the downloaded file is a temporary file, it's stored here so that the reference stays
@@ -12,6 +12,7 @@ pub struct DownloadedFile {
     pub file: File,
     pub url: DecodedUrl,
     pub mmap: Mmap,
+    pub override_arch: Option<Architecture>,
     pub sha_256: Sha256String,
     pub file_name: String,
     pub last_modified: Option<NaiveDate>,

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -6,19 +6,18 @@ use const_format::formatcp;
 pub use downloader::Downloader;
 pub use file::DownloadedFile;
 use reqwest::{Client, ClientBuilder, Response, header::HeaderValue, redirect::Policy};
-use url::Url;
 use uuid::Uuid;
-use winget_types::{installer::VALID_FILE_EXTENSIONS, url::DecodedUrl};
+use winget_types::installer::VALID_FILE_EXTENSIONS;
 
-use crate::github::github_client::GITHUB_HOST;
+use crate::{github::github_client::GITHUB_HOST, manifests::Url};
 
 #[derive(Debug, Clone)]
 pub struct Download {
-    pub url: DecodedUrl,
+    pub url: Url,
 }
 
 impl Download {
-    pub const fn new(url: DecodedUrl) -> Self {
+    pub const fn new(url: Url) -> Self {
         Self { url }
     }
 
@@ -32,7 +31,7 @@ impl Download {
     /// If there is no Content-Disposition header or no filenames in the Content-Disposition, it falls
     /// back to getting the last part of the initial URL and then the final redirected URL if the
     /// initial URL does not have a valid file extension at the end.
-    fn file_name(&self, final_url: &Url, content_disposition: Option<&HeaderValue>) -> String {
+    fn file_name(&self, final_url: &url::Url, content_disposition: Option<&HeaderValue>) -> String {
         const FILENAME: &str = "filename";
         const FILENAME_EXT: &str = formatcp!("{FILENAME}*");
 
@@ -131,7 +130,7 @@ impl Download {
                 if let Err(error) = limited_redirect_client.head(self.url.as_str()).send().await {
                     if error.is_redirect() {
                         if let Some(final_url) = error.url() {
-                            *self.url = final_url.clone();
+                            **self.url = final_url.clone();
                         }
                     }
                 }

--- a/src/download_file.rs
+++ b/src/download_file.rs
@@ -13,15 +13,16 @@ pub async fn process_files(
         |DownloadedFile {
              url,
              mmap,
+             override_arch,
              sha_256,
              file_name,
              last_modified,
              ..
          }| async move {
             let mut file_analyser = FileAnalyser::new(mmap, file_name)?;
-            let architecture_in_url = Architecture::from_url(url.as_str());
+            let architecture = override_arch.or_else(|| Architecture::from_url(url.as_str()));
             for installer in &mut file_analyser.installers {
-                if let Some(architecture) = architecture_in_url {
+                if let Some(architecture) = architecture {
                     installer.architecture = architecture;
                 }
                 installer.url = url.clone();

--- a/src/manifests/mod.rs
+++ b/src/manifests/mod.rs
@@ -12,6 +12,7 @@ use const_format::concatc;
 use owo_colors::{OwoColorize, Style, colors::css::SlateGrey};
 use serde::Serialize;
 use tree_sitter_highlight::{Highlight, HighlightConfiguration, HighlightEvent, Highlighter};
+pub use url::Url;
 use winget_types::{
     Manifest,
     installer::InstallerManifest,
@@ -20,6 +21,7 @@ use winget_types::{
 };
 
 pub mod manifest;
+mod url;
 
 pub struct Manifests {
     pub installer: InstallerManifest,

--- a/src/manifests/url.rs
+++ b/src/manifests/url.rs
@@ -1,0 +1,81 @@
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+    str::FromStr,
+};
+
+use url::ParseError;
+use winget_types::{installer::Architecture, url::DecodedUrl};
+
+#[derive(Clone, Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+pub struct Url {
+    inner: DecodedUrl,
+    override_architecture: Option<Architecture>,
+}
+
+impl Url {
+    #[inline]
+    pub fn override_architecture(&self) -> Option<Architecture> {
+        self.override_architecture
+    }
+
+    #[inline]
+    pub fn inner(&self) -> &DecodedUrl {
+        &self.inner
+    }
+
+    #[inline]
+    pub fn inner_mut(&mut self) -> &mut DecodedUrl {
+        &mut self.inner
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> DecodedUrl {
+        self.inner
+    }
+}
+
+impl Deref for Url {
+    type Target = DecodedUrl;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl DerefMut for Url {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl fmt::Display for Url {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.inner().fmt(f)
+    }
+}
+
+impl FromStr for Url {
+    type Err = ParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (url, architecture) = s.rsplit_once('|').unwrap_or((s, ""));
+
+        Ok(Url {
+            inner: url.parse()?,
+            override_architecture: architecture.parse().ok(),
+        })
+    }
+}
+
+impl From<DecodedUrl> for Url {
+    fn from(url: DecodedUrl) -> Self {
+        Self {
+            inner: url,
+            override_architecture: None,
+        }
+    }
+}


### PR DESCRIPTION
Adds the ability to override detected architecture by appending `|<architecture>` at the end of a URL like [wingetcreate](https://github.com/microsoft/winget-create/blob/main/doc/update.md#override-architecture).