### PR TITLE
Add usage examples to `komac complete --help`

### DIFF
--- a/src/commands/complete.rs
+++ b/src/commands/complete.rs
@@ -4,9 +4,15 @@ use clap_complete::{Shell, generate};
 
 use crate::Cli;
 
-/// Outputs an autocompletion script for the given shell
+/// Outputs an autocompletion script for the given shell. Example usage:
+/// 
+/// Bash: echo "source <(komac complete bash)" >> ~/.bashrc
+/// Elvish: echo "eval (komac complete elvish | slurp)" >> ~/.elvish/rc.elv
+/// Fish: echo "source (komac complete fish | psub)" >> ~/.config/fish/config.fish
+/// Powershell: echo "komac complete powershell | Out-String | Invoke-Expression" >> $PROFILE
+/// Zsh: echo "source <(komac complete zsh)" >> ~/.zshrc
 #[derive(Parser)]
-#[clap(visible_alias = "autocomplete")]
+#[clap(visible_alias = "autocomplete", verbatim_doc_comment)]
 pub struct Complete {
     #[arg(value_enum)]
     shell: Shell,


### PR DESCRIPTION
Fixes #1219. Examples sourced from https://docs.rs/clap_complete/4.5.50/clap_complete/env/index.html