### PR TITLE
Fix multiple display names in Burn MSI packages

### DIFF
--- a/src/installers/burn/manifest/package/msi/mod.rs
+++ b/src/installers/burn/manifest/package/msi/mod.rs
@@ -30,7 +30,7 @@ pub struct MsiPackage<'manifest> {
     #[serde(rename = "MsiProperty", borrow, default)]
     pub properties: Vec<MsiProperty<'manifest>>,
     #[serde(borrow)]
-    pub provides: Provides<'manifest>,
+    pub provides: Vec<Provides<'manifest>>,
     #[serde(default, borrow)]
     pub related_package: Vec<RelatedPackage<'manifest>>,
 }

--- a/src/installers/burn/mod.rs
+++ b/src/installers/burn/mod.rs
@@ -103,7 +103,9 @@ impl Burn {
             {
                 apps_and_features_entries.push(
                     AppsAndFeaturesEntry::builder()
-                        .maybe_display_name(msi_package.provides.iter().find_map(|p| p.display_name))
+                        .maybe_display_name(
+                            msi_package.provides.iter().find_map(|p| p.display_name),
+                        )
                         .maybe_publisher(manifest.registration.arp.publisher)
                         .display_version(msi_package.version)
                         .product_code(msi_package.product_code)

--- a/src/installers/burn/mod.rs
+++ b/src/installers/burn/mod.rs
@@ -104,7 +104,9 @@ impl Burn {
             {
                 apps_and_features_entries.push(
                     AppsAndFeaturesEntry::new()
-                        .with_display_name::<_, &str>(msi_package.provides.display_name)
+                        .with_display_name::<_, &str>(
+                            msi_package.provides.iter().find_map(|p| p.display_name),
+                        )
                         .with_publisher::<_, &str>(manifest.registration.arp.publisher)
                         .with_display_version(msi_package.version)
                         .with_product_code(msi_package.product_code)


### PR DESCRIPTION
Tested with `Microsoft.VCRedist.2012.x64`

Before:
```
Error:
   0: duplicate field `Provides`
```

After:
```yml
Architecture: x86
InstallerType: burn
Scope: machine
InstallerUrl: https://example.com/
InstallerSha256: '0000000000000000000000000000000000000000000000000000000000000000'
AppsAndFeaturesEntries:
- DisplayName: Microsoft Visual C++ 2012 Redistributable (x64) - 11.0.61030
  Publisher: Microsoft Corporation
  DisplayVersion: 11.0.61030.0
  ProductCode: '{ca67548a-5ebe-413a-b50c-4b9ceb6d66c6}'
  UpgradeCode: '{5A873082-F5A7-39E3-98EF-2BEE580CD698}'
  InstallerType: burn
- Publisher: Microsoft Corporation
  DisplayVersion: 11.0.61030
  ProductCode: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
  InstallerType: wix
- Publisher: Microsoft Corporation
  DisplayVersion: 11.0.61030
  ProductCode: '{37B8F9C7-03FB-3253-8781-2517C99D7C00}'
  InstallerType: wix
```