### PR TITLE
Fix Burn XML-encoded URLs

### DIFF
--- a/src/installers/burn/manifest/arp.rs
+++ b/src/installers/burn/manifest/arp.rs
@@ -17,13 +17,13 @@ pub struct Arp<'manifest> {
     #[serde(rename = "@Publisher")]
     pub publisher: Option<&'manifest str>,
     #[serde(rename = "@HelpLink")]
-    pub help_link: Option<&'manifest str>,
+    pub help_link: Option<String>,
     #[serde(rename = "@HelpTelephone")]
     pub help_telephone: Option<&'manifest str>,
     #[serde(rename = "@AboutUrl")]
-    pub about_url: Option<&'manifest str>,
+    pub about_url: Option<String>,
     #[serde(rename = "@UpdateUrl")]
-    pub update_url: Option<&'manifest str>,
+    pub update_url: Option<String>,
     #[serde(rename = "@ParentDisplayName")]
     pub parent_display_name: Option<&'manifest str>,
     #[serde(rename = "@DisableModify", default)]

--- a/src/installers/burn/manifest/container.rs
+++ b/src/installers/burn/manifest/container.rs
@@ -12,7 +12,7 @@ pub struct Container<'manifest> {
     #[serde(rename = "@Hash")]
     pub hash: &'manifest str,
     #[serde(rename = "@DownloadUrl")]
-    pub download_url: Option<&'manifest str>,
+    pub download_url: Option<String>,
     #[serde(rename = "@FilePath")]
     pub file_path: &'manifest str,
     #[serde(rename = "@AttachedIndex")]

--- a/src/installers/burn/manifest/payload/mod.rs
+++ b/src/installers/burn/manifest/payload/mod.rs
@@ -24,7 +24,7 @@ pub struct Payload<'manifest> {
     #[serde(rename = "@LayoutOnly", deserialize_with = "bool_from_yes_no", default)]
     pub layout_only: bool,
     #[serde(rename = "@DownloadUrl")]
-    pub download_url: Option<&'manifest str>,
+    pub download_url: Option<String>,
     #[serde(rename = "@Packaging", default)]
     pub packaging: Packaging,
     #[serde(rename = "@SourcePath")]


### PR DESCRIPTION
Tested with Workday Office Connect (https://clickonce.adaptiveinsights.com/officeconnect/latest/OfficeConnectSetup.exe)

Before:
```
Error:
   0: invalid type: string "http://doc.workday.com/access/sources/dita/topic?wd:docset=adaptivehelp&ft:locale=en-US&resourceid=rep-oc", expected a borrowed string
```

After:
```
Architecture: x86
InstallerType: burn
Scope: user
InstallerUrl: https://example.com/
InstallerSha256: '0000000000000000000000000000000000000000000000000000000000000000'
AppsAndFeaturesEntries:
- DisplayName: OfficeConnect
  Publisher: Workday, Inc.
  DisplayVersion: 2025.102.1819.1857
  ProductCode: '{374a697f-73a2-4322-922d-f57cebd4fecd}'
  UpgradeCode: '{BCD463A6-B069-44C4-B0DA-A8F6674CFF55}'
  InstallerType: burn
```