### PR TITLE
fix: preserve nested installer metadata during version updates to perserve existing `PortableCommandAlias` #1392

### DIFF
--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -183,11 +183,13 @@ impl UpdateVersion {
                 ]
                 .into_iter()
                 .find(|files| !files.is_empty())
-                .unwrap()
-                .clone();
+                .cloned();
 
-                installer.nested_installer_files =
-                    fix_relative_paths(nested_files_to_fix, analyser.zip.as_ref());
+                if let Some(nested_files) = nested_files_to_fix {
+                    installer.nested_installer_files =
+                        fix_relative_paths(nested_files, analyser.zip.as_ref());
+                }
+
                 for entry in &mut installer.apps_and_features_entries {
                     entry.deduplicate(&manifests.default_locale);
                 }


### PR DESCRIPTION
Wanted to give a shot at this issue: #1392

- Maintains existing data to prevent loss in nested installer files fallback logic
- Preserve PortableCommandAlias and other metadata fields when updating versions

Resolves issue where PortableCommandAlias (e.g., kubectl-oidc_login) was lost when updating packages due to incorrect fallback replacing all nested files instead of preserving existing ones.

See here how these commands now have a PortableCommandAlias:
<img width="3789" height="2043" alt="image" src="https://github.com/user-attachments/assets/f5aacd30-a381-4296-a959-fbc2dc012461" />
