### PR TITLE
Fix incorrect MSIX `DisplayName`

### DIFF
--- a/src/analysis/installers/msix_family/mod.rs
+++ b/src/analysis/installers/msix_family/mod.rs
@@ -83,8 +83,10 @@ impl Msix {
                         }
                     }
                     b"DisplayName" => {
-                        manifest.properties.display_name =
-                            reader.read_text(event.to_end().name())?.into_owned();
+                        if event.name().prefix().is_none() {
+                            manifest.properties.display_name =
+                                reader.read_text(event.to_end().name())?.into_owned();
+                        }
                     }
                     b"PublisherDisplayName" => {
                         manifest.properties.publisher_display_name =


### PR DESCRIPTION
Prevents elements with a namespace (like `<uap:DisplayName>mailto</uap:DisplayName>`) from being parsed as the package `DisplayName`.

Fixes #1494