### PR TITLE
Handle empty paths in NSIS file deletion

### DIFF
--- a/src/analysis/installers/nsis/entry/mod.rs
+++ b/src/analysis/installers/nsis/entry/mod.rs
@@ -659,12 +659,8 @@ impl Entry {
             }
             Self::RemoveDir { path, flags } => {
                 let path = state.get_string(path.get());
-                if path.as_ref() == "" {
-                    debug!(r#"RMDir: "" (ignored empty path)"#);
-                } else {
-                    debug!(r#"RMDir: "{path}""#);
-                    state.file_system.delete(path, *flags);
-                }
+                debug!(r#"RMDir: "{path}""#);
+                state.file_system.delete(path, *flags);
             }
             Self::StrLen { output, input } => {
                 let input = state.get_string(input.get());

--- a/src/analysis/installers/nsis/file_system/mod.rs
+++ b/src/analysis/installers/nsis/file_system/mod.rs
@@ -173,6 +173,11 @@ impl FileSystem {
     {
         let name = name.as_ref();
 
+        // Return false if the path is empty; it cannot be deleted
+        if name.is_empty() {
+            return false;
+        }
+
         if flags.contains(DelFlags::SIMPLE) {
             if let Some(file) = self.current_dir.children(&self.arena).find(|&id| {
                 self.arena


### PR DESCRIPTION
Fixes #1502

`cargo run analyse SteelSeriesGG98.0.0Setup.exe` before:
```
<snip>
DEBUG komac::analysis::installers::nsis::entry: SetOutPath: "%ProgramFiles(x86)%\SteelSeries\GG"
DEBUG komac::analysis::installers::nsis::entry: ExtractFile: "vulkan-1.dll" 2025-11-04 19:11:24 UTC
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: Call: 5775
DEBUG komac::analysis::installers::nsis::entry: Call: 8650
DEBUG komac::analysis::installers::nsis::entry: SetDetailsPrintFlag none
DEBUG komac::analysis::installers::nsis::entry: StrCmp: "Plugins" "" eq: 0 ne: 8661
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: SetDetailsPrintFlag both
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: Call: 7267
DEBUG komac::analysis::installers::nsis::entry: RMDir: ""
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: SetOutPath: "%ProgramFiles(x86)%\SteelSeries\GG"
The application panicked (crashed).
Message:  internal error: entered unreachable code: Try to access a freed node
Location: /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/indextree-4.7.4/src/node.rs:45
```

After:
```
<snip>
DEBUG komac::analysis::installers::nsis::entry: SetOutPath: "%ProgramFiles(x86)%\SteelSeries\GG"
DEBUG komac::analysis::installers::nsis::entry: ExtractFile: "vulkan-1.dll" 2025-11-04 19:11:24 UTC
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: Call: 5775
DEBUG komac::analysis::installers::nsis::entry: Call: 8650
DEBUG komac::analysis::installers::nsis::entry: SetDetailsPrintFlag none
DEBUG komac::analysis::installers::nsis::entry: StrCmp: "Plugins" "" eq: 0 ne: 8661
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: SetDetailsPrintFlag both
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: Call: 7267
DEBUG komac::analysis::installers::nsis::entry: RMDir: "" (ignored empty path)
DEBUG komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis::entry: SetOutPath: "%ProgramFiles(x86)%\SteelSeries\GG"
DEBUG komac::analysis::installers::nsis::entry: ExtractFile: "version.json" 2025-11-04 17:57:28 UTC
<snip>
InstallerLocale: en-US
Architecture: x86
InstallerType: nullsoft
Scope: machine
InstallerUrl: https://example.com/
InstallerSha256: '0000000000000000000000000000000000000000000000000000000000000000'
ProductCode: SteelSeries GG
AppsAndFeaturesEntries:
- DisplayName: SteelSeries GG 98.0.0
  Publisher: SteelSeries ApS
  DisplayVersion: 98.0.0
  ProductCode: SteelSeries GG
InstallationMetadata:
  DefaultInstallLocation: '%ProgramFiles(x86)%\SteelSeries\GG'
```