### PR TITLE
Parse NSIS install directory after version

### DIFF
--- a/src/analysis/installers/nsis/state.rs
+++ b/src/analysis/installers/nsis/state.rs
@@ -59,12 +59,6 @@ impl<'data> NsisState<'data> {
             version: NsisVersion::default(),
         };
 
-        if header.has_install_directory() {
-            let install_dir = state.get_string(header.install_directory_ptr());
-            debug!(%install_dir);
-            state.variables.insert_install_dir(install_dir);
-        }
-
         let manifest = pe
             .resources
             .iter()
@@ -81,6 +75,12 @@ impl<'data> NsisState<'data> {
             .unwrap_or_else(|| NsisVersion::detect(state.str_block));
 
         debug!(version = %state.version);
+
+        if header.has_install_directory() {
+            let install_dir = state.get_string(header.install_directory_ptr());
+            debug!(%install_dir);
+            state.variables.insert_install_dir(install_dir);
+        }
 
         Ok(state)
     }


### PR DESCRIPTION
Fixes #1451 because `version` is used by `get_string`. The AltSnap path matches some older manifests, so this might be a regression

`cargo run analyse disksorter_setup_v17.3.12_x64.exe` before:

```
DEBUG komac::analysis::installers::nsis::state: install_dir=þÁ"\Disk Sorter
DEBUG komac::analysis::installers::nsis::version: branding_text=NSIS v2.46
TRACE komac::analysis::installers::nsis::version: Detecting version from strings block
DEBUG komac::analysis::installers::nsis::version: unicode=false
DEBUG komac::analysis::installers::nsis::version: nsis3_count=1 nsis2_count=51
DEBUG komac::analysis::installers::nsis::state: version=2.00
```

After:

```
DEBUG komac::analysis::installers::nsis::version: branding_text=NSIS v2.46
TRACE komac::analysis::installers::nsis::version: Detecting version from strings block
DEBUG komac::analysis::installers::nsis::version: unicode=false
DEBUG komac::analysis::installers::nsis::version: nsis3_count=1 nsis2_count=51
DEBUG komac::analysis::installers::nsis::state: version=2.00
DEBUG komac::analysis::installers::nsis::state: install_dir=%ProgramFiles%\Disk Sorter
```

`cargo run analyse AltSnap1.67-inst.exe` before:

```
DEBUG komac::analysis::installers::nsis::state: install_dir=þ#\AltSnap\
DEBUG komac::analysis::installers::nsis::version: branding_text=Nullsoft Install System v2.20
DEBUG komac::analysis::installers::nsis::state: version=2.20
```

After:

```
DEBUG komac::analysis::installers::nsis::version: branding_text=Nullsoft Install System v2.20
DEBUG komac::analysis::installers::nsis::state: version=2.20
DEBUG komac::analysis::installers::nsis::state: install_dir=%AppData%\AltSnap\
```