### PR TITLE
Use `AppVerName` as DisplayName if `UninstallDisplayName` isn't present

### DIFF
--- a/src/analysis/installers/inno/mod.rs
+++ b/src/analysis/installers/inno/mod.rs
@@ -55,7 +55,11 @@ impl Installers for Inno {
                 || self.header.app_version().is_some()
             {
                 AppsAndFeaturesEntry::builder()
-                    .maybe_display_name(self.header.uninstall_name())
+                    .maybe_display_name(
+                        self.header
+                            .uninstall_name()
+                            .or(self.header.app_versioned_name()),
+                    )
                     .maybe_publisher(self.header.app_publisher())
                     .maybe_display_version(self.header.app_version())
                     .maybe_product_code(self.header.product_code())


### PR DESCRIPTION
https://github.com/TeXworks/texworks/releases/download/release-0.6.10/TeXworks-win10-setup-0.6.10-202502131411-git_7380941.exe
```
komac analyze TeXworks-win10-setup-0.6.10-202502131411-git_7380941.exe
```
Before:
```yaml
AppsAndFeaturesEntries:
- Publisher: TeX Users Group
  ProductCode: '{41DA4817-4D2A-4D83-AD02-6A2D95DC8DCB}_is1'
```
After:
```yaml
AppsAndFeaturesEntries:
- DisplayName: TeXworks 0.6.10
  Publisher: TeX Users Group
  ProductCode: '{41DA4817-4D2A-4D83-AD02-6A2D95DC8DCB}_is1'
```
https://jrsoftware.org/ishelp/index.php?topic=setup_uninstalldisplayname