### PR TITLE
Wrap GitHub errors so they're displayed

### DIFF
--- a/src/github/error.rs
+++ b/src/github/error.rs
@@ -1,4 +1,4 @@
-use color_eyre::{Report, Section, eyre};
+use color_eyre::{Report, eyre};
 use cynic::http::CynicReqwestError;
 use thiserror::Error;
 use winget_types::{ManifestType, PackageIdentifier};
@@ -39,7 +39,7 @@ impl GitHubError {
                 .into()
                 .unwrap_or_default()
                 .into_iter()
-                .fold(err, Report::error),
+                .fold(err, Report::wrap_err),
         )
     }
 }


### PR DESCRIPTION
Not sure if this is idiomatic, but it helped me

Before

```
Error: 
   0: failed to create branch Git.Git-2.52.0-88AAAF65DEEA4771A699381881ED6D43
```

After

```
Error: 
   0: pl4nty does not have the correct permissions to execute `CreateRef`
   1: failed to create branch Git.Git-2.52.0-88AAAF65DEEA4771A699381881ED6D43
```