### PR TITLE
docs: GitHub token setup using GitHub CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Adding to komac:
 komac token add
 ```
 
-The token can be conveniently obtained using the following [GitHub CLI](https://cli.github.com/) command:
+The token can be also be obtained using the [GitHub CLI](https://cli.github.com/):
 
 ```bash
 komac token add --token=$(gh auth token)


### PR DESCRIPTION
Adds command example for pure CLI procedure to obtain GitHub token and set it up for Komac.

The command works on Linux as well as Windows in PowerShell:

<img width="656" height="50" alt="Screenshot 2026-01-17 155627" src="https://github.com/user-attachments/assets/7ab249aa-f3c1-40f4-ae71-cdd90922839c" />
