### PR TITLE
Detect NSIS arch from electron-builder files

### DIFF
--- a/src/analysis/installers/nsis/file_system/entry.rs
+++ b/src/analysis/installers/nsis/file_system/entry.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use compact_str::CompactString;
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum Item {
+pub enum FsEntry {
     File {
         name: CompactString,
         modified_at: Option<DateTime<Utc>>,
@@ -13,7 +13,7 @@ pub enum Item {
     Directory(CompactString),
 }
 
-impl Item {
+impl FsEntry {
     #[inline]
     pub const fn new_root() -> Self {
         Self::Directory(CompactString::const_new("/"))
@@ -70,7 +70,7 @@ impl Item {
     }
 }
 
-impl fmt::Debug for Item {
+impl fmt::Debug for FsEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::File {
@@ -93,7 +93,7 @@ impl fmt::Debug for Item {
     }
 }
 
-impl fmt::Display for Item {
+impl fmt::Display for FsEntry {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.name().fmt(f)
     }

--- a/src/analysis/installers/nsis/file_system/mod.rs
+++ b/src/analysis/installers/nsis/file_system/mod.rs
@@ -1,4 +1,4 @@
-mod item;
+mod entry;
 
 use std::{
     fmt,
@@ -8,14 +8,14 @@ use std::{
 
 use camino::{Utf8Component, Utf8Path};
 use chrono::{DateTime, Utc};
+pub use entry::FsEntry;
 use indextree::{Arena, Node, NodeId};
-pub use item::Item;
 use itertools::{Either, Itertools, Position};
 
 use super::{entry::DelFlags, strings::PredefinedVar};
 
 pub struct FileSystem {
-    arena: Arena<Item>,
+    arena: Arena<FsEntry>,
     root: NodeId,
     current_dir: NodeId,
 }
@@ -29,7 +29,7 @@ pub enum RelativeLocation {
 impl FileSystem {
     pub fn new() -> Self {
         let mut arena = Arena::new();
-        let root = arena.new_node(Item::new_root());
+        let root = arena.new_node(FsEntry::new_root());
         Self {
             arena,
             root,
@@ -87,7 +87,8 @@ impl FileSystem {
                     }) {
                         current = directory;
                     } else {
-                        current = current.append_value(Item::new_directory(part), &mut self.arena);
+                        current =
+                            current.append_value(FsEntry::new_directory(part), &mut self.arena);
                     }
                 }
                 _ => {}
@@ -127,7 +128,7 @@ impl FileSystem {
         }) {
             Some(file)
         } else {
-            let file = Item::new_file(file_name, created_at, position);
+            let file = FsEntry::new_file(file_name, created_at, position);
             Some(directory.append_value(file, &mut self.arena))
         }
     }
@@ -235,22 +236,40 @@ impl FileSystem {
         false
     }
 
-    pub fn directories(&self) -> impl Iterator<Item = &Item> {
+    /// Returns an iterator over all entries in the filesystem.
+    ///
+    /// The iteration order is identical to [`NodeId::descendants`], but with node IDs resolved to
+    /// [filesystem entries].
+    ///
+    /// [filesystem entries]: FsEntry
+    pub fn entries(&self) -> impl Iterator<Item = &FsEntry> {
         self.root
             .descendants(&self.arena)
             .filter_map(|id| self.arena.get(id).map(Node::get))
-            .filter(|item| item.is_directory())
     }
 
-    pub fn files(&self) -> impl Iterator<Item = &Item> {
-        self.root
-            .descendants(&self.arena)
-            .filter_map(|id| self.arena.get(id).map(Node::get))
-            .filter(|item| item.is_file())
+    /// Returns an iterator over all directories in the filesystem.
+    ///
+    /// The iteration order is identical to [`NodeId::descendants`], but with node IDs resolved to
+    /// [filesystem entries].
+    ///
+    /// [filesystem entries]: FsEntry
+    pub fn directories(&self) -> impl Iterator<Item = &FsEntry> {
+        self.entries().filter(|item| item.is_directory())
+    }
+
+    /// Returns an iterator over all files in the filesystem.
+    ///
+    /// The iteration order is identical to [`NodeId::descendants`], but with node IDs resolved to
+    /// [filesystem entries].
+    ///
+    /// [filesystem entries]: FsEntry
+    pub fn files(&self) -> impl Iterator<Item = &FsEntry> {
+        self.entries().filter(|item| item.is_file())
     }
 
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = &Item> {
+    pub fn iter(&self) -> impl Iterator<Item = &FsEntry> {
         self.into_iter()
     }
 }
@@ -275,9 +294,10 @@ impl Default for FileSystem {
 }
 
 impl<'a> IntoIterator for &'a FileSystem {
-    type Item = &'a Item;
+    type Item = &'a FsEntry;
 
-    type IntoIter = FilterMap<Iter<'a, Node<Item>>, fn(&'a Node<Item>) -> Option<&'a Item>>;
+    type IntoIter =
+        FilterMap<Iter<'a, Node<FsEntry>>, fn(&'a Node<FsEntry>) -> Option<&'a FsEntry>>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.arena

--- a/src/analysis/installers/nsis/mod.rs
+++ b/src/analysis/installers/nsis/mod.rs
@@ -42,7 +42,7 @@ use super::{
     super::extensions::EXE,
     nsis::{
         entry::{Entry, EntryError},
-        file_system::Item,
+        file_system::FsEntry,
         first_header::FirstHeader,
         header::{
             Compression, Decoder, Decompressed, Header, block::BlockHeaders,
@@ -145,20 +145,13 @@ impl Nsis {
         let mut architecture =
             Option::from(architecture).filter(|&architecture| architecture != Architecture::X86);
 
-        for directory in state.file_system.directories().map(Item::name) {
-            // If there is an app-64 file, the app is x64.
-            // If there is an app-32 file or both files are present, the app is x86
+        for entry in state.file_system.entries().map(FsEntry::name) {
+            // If there is an app-64 entry, the app is x64.
+            // If there is an app-32 entry or both entries are present, the app is x86.
             // (x86 apps can still install on x64 systems)
-            if directory == APP_64 && architecture.is_none() {
+            if entry.contains(APP_64) && architecture.is_none() {
                 architecture = Some(Architecture::X64);
-            } else if directory == APP_32 {
-                architecture = Some(Architecture::X86);
-            }
-        }
-        for file in state.file_system.files().map(Item::name) {
-            if file.contains(APP_64) && architecture.is_none() {
-                architecture = Some(Architecture::X64);
-            } else if file.contains(APP_32) {
+            } else if entry.contains(APP_32) {
                 architecture = Some(Architecture::X86);
             }
         }


### PR DESCRIPTION
NSIS arch is already detected from electron-builder `app-32` or `app-64` folders, but sometimes they're not created due to emulation limitations (eg System plugin). The filesystem might look like this:

```
DEBUG komac::analysis::installers::nsis: state.file_system=/
|-- Plugins\System.dll
|-- Plugins\SpiderBanner.dll
|-- Plugins\StdUtils.dll
|-- Plugins\nsProcess.dll
|-- Plugins\app-64.7z
|   |-- Plugins\StdUtils.dll
|   |-- %LocalAppData%\batch-explorer-updater\installer.exe
|   |-- Uninstall BatchExplorer.exe
|   |-- Plugins\WinShell.dll
|   `-- Plugins\System.dll
`-- Plugins\7z-out
    `-- Plugins\nsis7z.dll
```

So we can also check for `app-32` or `app-64` in filenames. Tested with https://github.com/microsoft/winget-pkgs/pull/331443