### PR TITLE
Fix Burn install condition integers and lowercase operators

### DIFF
--- a/src/analysis/installers/burn/manifest/package/install_condition.rs
+++ b/src/analysis/installers/burn/manifest/package/install_condition.rs
@@ -219,7 +219,7 @@ fn tokenize(input: &str) -> Vec<Token> {
             '0'..='9' => {
                 let mut value = 0;
                 while let Some(digit) = chars.peek().and_then(|char| char.to_digit(10)) {
-                    value *= 10 + digit;
+                    value = value * 10 + digit;
                     chars.next();
                 }
                 tokens.push(Token::Number(value));
@@ -232,7 +232,7 @@ fn tokenize(input: &str) -> Vec<Token> {
                     ident.push(char);
                     chars.next();
                 }
-                tokens.push(match ident.as_str() {
+                tokens.push(match ident.to_uppercase().as_str() {
                     AND => Token::And,
                     OR => Token::Or,
                     NOT => Token::Not,


### PR DESCRIPTION
The lowercase operators causes a crash on https://github.com/microsoft/winget-pkgs/blob/master/manifests/p/Python/Python/3/12/3.12.10/Python.Python.3.12.installer.yaml. Spotted the integer bug while I was there

```
The application panicked (crashed).
Message:  Expected RParen, got Some(Ident("or"))
Location: src\analysis\installers\burn\manifest\package\install_condition.rs
```

After:

```
Architecture: x86
InstallerType: burn
Scope: user
InstallerUrl: https://example.com/
InstallerSha256: '0000000000000000000000000000000000000000000000000000000000000000'
AppsAndFeaturesEntries:
- DisplayName: Python 3.12.10 (64-bit)
  Publisher: Python Software Foundation
  DisplayVersion: 3.12.10150.0
  ProductCode: '{b6ce88eb-2ce3-4d91-8efc-425ae1f48caf}'
  UpgradeCode: '{114AEC44-152B-5746-952F-F20CE3CAB54A}'
  InstallerType: burn
- DisplayName: Python Launcher
  Publisher: Python Software Foundation
  DisplayVersion: 3.12.10150.0
  ProductCode: '{665A0435-D5D5-4A49-9DE0-FBC23C5425ED}'
  InstallerType: wix
```