### PR TITLE
docs(readme): Add link to install-komac action

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ jobs:
 
 - Run Komac manually: [michidk/run-komac](https://github.com/michidk/run-komac)
 - Automate releases for external repositories: [michidk/winget-updater](https://github.com/michidk/winget-updater)
-- Install and Run Komac manually or automatically: [UnownPlain/install-komac](https://github.com/UnownPlain/install-komac)
+- Install and run Komac: [UnownPlain/install-komac](https://github.com/UnownPlain/install-komac)
 
 ## How can I support Komac? ❤️
 


### PR DESCRIPTION
Adds a link to UnownPlain's [install-komac](https://github.com/UnownPlain/install-komac) action.

This action installs the latest version or specified version into the GHA job.