### PR TITLE
Fix commit error when trying to replace updated version

### DIFF
--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -294,13 +294,17 @@ impl UpdateVersion {
         versions: &'a BTreeSet<PackageVersion>,
         latest_version: &'a PackageVersion,
     ) -> Result<Option<&'a PackageVersion>> {
-        let replace_version = self.replace.as_ref().map(|version| {
-            if version.is_latest() {
-                latest_version
-            } else {
-                version
-            }
-        });
+        let replace_version = self
+            .replace
+            .as_ref()
+            .map(|version| {
+                if version.is_latest() {
+                    latest_version
+                } else {
+                    version
+                }
+            })
+            .filter(|&version| version.as_str() != self.package_version.as_str());
 
         if let Some(version) = replace_version
             && !versions.contains(version)


### PR DESCRIPTION
This basically reverts 2b2869a but changes the comparison to the raw version instead of PackageVersion. I also created microsoft/winget-pkgs#334343 to make sure the issue that commit fixed didn't come back.