### PR TITLE
Lowercase RelativeFilePath extensions

### DIFF
--- a/src/analysis/installers/zip.rs
+++ b/src/analysis/installers/zip.rs
@@ -15,6 +15,7 @@ use zip::ZipArchive;
 
 use super::super::Analyzer;
 use crate::prompts::{handle_inquire_error, text::required_prompt};
+use crate::traits::path::LowercaseExtension;
 
 const VALID_NESTED_FILE_EXTENSIONS: [&str; 6] =
     ["msix", "msi", "appx", "exe", "msixbundle", "appxbundle"];
@@ -83,7 +84,7 @@ impl<R: Read + Seek> Zip<R> {
         {
             let chosen_file_name = &possible_installer_files[0];
             nested_installer_files = BTreeSet::from([NestedInstallerFiles {
-                relative_file_path: chosen_file_name.clone(),
+                relative_file_path: chosen_file_name.lowercase_extension(),
                 portable_command_alias: None,
             }]);
             if let Ok(mut chosen_file) = zip.by_name(chosen_file_name.as_str()) {
@@ -149,7 +150,7 @@ impl<R: Read + Seek> Zip<R> {
                         } else {
                             None
                         },
-                        relative_file_path: path,
+                        relative_file_path: path.lowercase_extension(),
                     })
                 })
                 .collect::<Result<BTreeSet<_>>>()?;

--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -37,7 +37,10 @@ use crate::{
     match_installers::match_installers,
     terminal::Hyperlinkable,
     token::TokenManager,
-    traits::{LocaleExt, path::NormalizePath},
+    traits::{
+        LocaleExt,
+        path::{LowercaseExtension, NormalizePath},
+    },
 };
 
 /// Add a version to a pre-existing package
@@ -378,7 +381,7 @@ fn fix_relative_paths<R: Read + Seek>(
                         )
                     })
                     .map(|path| NestedInstallerFiles {
-                        relative_file_path: path.to_path_buf(),
+                        relative_file_path: path.lowercase_extension(),
                         ..nested_installer_files
                     })
             }

--- a/src/traits/path.rs
+++ b/src/traits/path.rs
@@ -9,6 +9,16 @@ pub trait NormalizePath {
     fn normalize(&self) -> Utf8PathBuf;
 }
 
+pub trait LowercaseExtension {
+    fn lowercase_extension(&self) -> Utf8PathBuf;
+}
+
+impl LowercaseExtension for Utf8PathBuf {
+    fn lowercase_extension(&self) -> Utf8PathBuf {
+        self.with_extension(self.extension().unwrap_or_default().to_ascii_lowercase())
+    }
+}
+
 impl NormalizePath for Utf8Path {
     fn normalize(&self) -> Utf8PathBuf {
         let mut components = self.components().peekable();


### PR DESCRIPTION
The validation pipelines require `RelativeFilePath`s extensions to be lowercase

https://dev.azure.com/shine-oss/winget-pkgs/_build/results?buildId=242020&view=results