### PR TITLE
Add `--files` argument to skip downloading `--urls`

### DIFF
--- a/src/commands/analyse.rs
+++ b/src/commands/analyse.rs
@@ -1,17 +1,15 @@
 use std::{
     fs::File,
-    io,
-    io::{Read, Seek, SeekFrom},
+    io::{Seek, SeekFrom},
 };
 
 use anstream::stdout;
 use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
 use color_eyre::{Result, eyre::ensure};
-use sha2::{Digest, Sha256, digest::Output};
 use winget_types::Sha256String;
 
-use crate::{analysis::Analyzer, manifests::print_manifest};
+use crate::{analysis::Analyzer, download::sha256_digest, manifests::print_manifest};
 
 /// Analyses a file and outputs information about it
 #[derive(Parser)]
@@ -64,21 +62,6 @@ impl Analyse {
         print_manifest(&mut lock, &yaml);
         Ok(())
     }
-}
-
-fn sha256_digest<R: Read>(mut reader: R) -> io::Result<Output<Sha256>> {
-    let mut digest = Sha256::new();
-    let mut buffer = [0; 1 << 13];
-
-    loop {
-        let count = reader.read(&mut buffer)?;
-        if count == 0 {
-            break;
-        }
-        digest.update(&buffer[..count]);
-    }
-
-    Ok(digest.finalize())
 }
 
 fn is_valid_file(path: &str) -> Result<Utf8PathBuf> {

--- a/src/commands/new_version.rs
+++ b/src/commands/new_version.rs
@@ -1,13 +1,13 @@
 use std::{
     collections::BTreeSet,
-    mem,
+    io, mem,
     num::{NonZeroU32, NonZeroUsize},
 };
 
 use anstream::println;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, ensure};
 use indicatif::ProgressBar;
 use inquire::CustomType;
 use ordinal::Ordinal;
@@ -34,7 +34,7 @@ use crate::{
     commands::utils::{
         SPINNER_TICK_RATE, SubmitOption, prompt_existing_pull_request, write_changes_to_dir,
     },
-    download::Downloader,
+    download::{DownloadedFile, Downloader},
     download_file::process_files,
     github::{
         GITHUB_HOST, WINGET_PKGS_FULL_NAME,
@@ -66,6 +66,10 @@ pub struct NewVersion {
     /// The list of package installers
     #[arg(short, long, num_args = 1.., value_hint = clap::ValueHint::Url)]
     urls: Vec<Url>,
+
+    /// The list of files to use instead of downloading urls
+    #[arg(short, long, num_args = 1.., value_hint = clap::ValueHint::FilePath, requires = "urls", value_parser = is_valid_file)]
+    files: Vec<Utf8PathBuf>,
 
     #[arg(long)]
     package_locale: Option<LanguageTag>,
@@ -155,6 +159,15 @@ pub struct NewVersion {
 
 impl NewVersion {
     pub async fn run(self) -> Result<()> {
+        if !self.files.is_empty() {
+            ensure!(
+                self.urls.len() == self.files.len(),
+                "Number of URLs ({}) must match number of files ({})",
+                self.urls.len(),
+                self.files.len()
+            );
+        }
+
         let token = TokenManager::handle(self.token).await?;
         let github = GitHub::new(&token)?;
 
@@ -219,8 +232,17 @@ impl NewVersion {
             }
         });
 
-        let downloader = Downloader::new_with_concurrent(self.concurrent_downloads)?;
-        let mut files = downloader.download(urls.iter().cloned()).await?;
+        let mut files = if self.files.is_empty() {
+            let downloader = Downloader::new_with_concurrent(self.concurrent_downloads)?;
+            downloader.download(urls.iter().cloned()).await?
+        } else {
+            self.files
+                .iter()
+                .zip(urls.iter().cloned())
+                .map(|(path, url)| DownloadedFile::from_local(path, url))
+                .collect::<io::Result<Vec<_>>>()?
+        };
+
         let mut download_results = process_files(&mut files).await?;
 
         let mut installers = Vec::new();
@@ -228,11 +250,9 @@ impl NewVersion {
             let mut silent = None;
             let mut silent_with_progress = None;
             let mut custom = None;
-            if analyser
-                .installers
-                .iter()
-                .any(|installer| installer.r#type == Some(InstallerType::Exe))
-            {
+            if analyser.installers.iter().any(|installer| {
+                installer.r#type == Some(InstallerType::Exe) && installer.switches.is_empty()
+            }) {
                 if confirm_prompt(&format!("Is {} a portable exe?", analyser.file_name))? {
                     for installer in &mut analyser.installers {
                         installer.r#type = Some(InstallerType::Portable);
@@ -479,4 +499,11 @@ impl NewVersion {
 
         Ok(())
     }
+}
+
+fn is_valid_file(path: &str) -> Result<Utf8PathBuf> {
+    let path = Utf8Path::new(path);
+    ensure!(path.exists(), "{path} does not exist");
+    ensure!(path.is_file(), "{path} is not a file");
+    Ok(path.to_path_buf())
 }

--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -1,14 +1,15 @@
 use std::{
     collections::BTreeSet,
+    io,
     io::{Read, Seek},
     mem,
     num::{NonZeroU32, NonZeroUsize},
 };
 
 use anstream::println;
-use camino::Utf8PathBuf;
+use camino::{Utf8Path, Utf8PathBuf};
 use clap::Parser;
-use color_eyre::eyre::{Error, Result, bail};
+use color_eyre::eyre::{Error, Result, bail, ensure};
 use futures_util::TryFutureExt;
 use indicatif::ProgressBar;
 use owo_colors::OwoColorize;
@@ -25,7 +26,7 @@ use crate::{
     commands::utils::{
         SPINNER_TICK_RATE, SubmitOption, prompt_existing_pull_request, write_changes_to_dir,
     },
-    download::Downloader,
+    download::{DownloadedFile, Downloader},
     download_file::process_files,
     github::{
         GITHUB_HOST, GitHubError, WINGET_PKGS_FULL_NAME,
@@ -55,6 +56,10 @@ pub struct UpdateVersion {
     /// The list of package installers
     #[arg(short, long, num_args = 1.., required = true, value_hint = clap::ValueHint::Url)]
     urls: Vec<Url>,
+
+    /// The list of files to use instead of downloading urls
+    #[arg(short, long, num_args = 1.., requires = "urls", value_parser = is_valid_file, value_hint = clap::ValueHint::FilePath)]
+    files: Vec<Utf8PathBuf>,
 
     /// Number of installers to download at the same time
     #[arg(long, default_value_t = NonZeroUsize::new(num_cpus::get()).unwrap())]
@@ -107,6 +112,15 @@ pub struct UpdateVersion {
 
 impl UpdateVersion {
     pub async fn run(self) -> Result<()> {
+        if !self.files.is_empty() {
+            ensure!(
+                self.urls.len() == self.files.len(),
+                "Number of URLs ({}) must match number of files ({})",
+                self.urls.len(),
+                self.files.len()
+            );
+        }
+
         let token = TokenManager::handle(self.token.as_deref()).await?;
         let github = GitHub::new(&token)?;
 
@@ -127,13 +141,24 @@ impl UpdateVersion {
             return Ok(());
         }
 
-        let downloader = Downloader::new_with_concurrent(self.concurrent_downloads)?;
         let (mut manifests, mut github_values, mut files) = try_join!(
             github
                 .get_manifests(&self.package_identifier, latest_version)
                 .map_err(Error::new),
             self.fetch_github_values(&github).map_err(Error::new),
-            downloader.download(self.urls.iter().cloned()),
+            async {
+                if self.files.is_empty() {
+                    let downloader = Downloader::new_with_concurrent(self.concurrent_downloads)?;
+                    downloader.download(self.urls.iter().cloned()).await
+                } else {
+                    self.files
+                        .iter()
+                        .zip(self.urls.iter().cloned())
+                        .map(|(path, url)| DownloadedFile::from_local(path, url))
+                        .collect::<io::Result<Vec<_>>>()
+                        .map_err(Error::new)
+                }
+            },
         )?;
 
         let mut download_results = process_files(&mut files).await?;
@@ -388,4 +413,11 @@ fn fix_relative_paths<R: Read + Seek>(
             }
         })
         .collect::<BTreeSet<_>>()
+}
+
+fn is_valid_file(path: &str) -> Result<Utf8PathBuf> {
+    let path = Utf8Path::new(path);
+    ensure!(path.exists(), "{path} does not exist");
+    ensure!(path.is_file(), "{path} is not a file");
+    Ok(path.to_path_buf())
 }

--- a/src/download/file.rs
+++ b/src/download/file.rs
@@ -1,6 +1,8 @@
-use std::fs::File;
+use std::{fs::File, io, io::Read};
 
+use camino::Utf8Path;
 use chrono::NaiveDate;
+use sha2::{Digest, Sha256, digest::Output};
 use winget_types::Sha256String;
 
 use crate::manifests::Url;
@@ -11,4 +13,34 @@ pub struct DownloadedFile {
     pub sha_256: Sha256String,
     pub file_name: String,
     pub last_modified: Option<NaiveDate>,
+}
+
+impl DownloadedFile {
+    pub fn from_local(path: &Utf8Path, url: Url) -> io::Result<Self> {
+        let file = File::open(path)?;
+        let sha_256 = Sha256String::from_digest(&sha256_digest(&file)?);
+        let file_name = path.file_name().unwrap_or_else(|| path.as_str()).to_owned();
+        Ok(Self {
+            file,
+            url,
+            sha_256,
+            file_name,
+            last_modified: None,
+        })
+    }
+}
+
+pub fn sha256_digest<R: Read>(mut reader: R) -> io::Result<Output<Sha256>> {
+    let mut digest = Sha256::new();
+    let mut buffer = [0; 1 << 13];
+
+    loop {
+        let count = reader.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        digest.update(&buffer[..count]);
+    }
+
+    Ok(digest.finalize())
 }

--- a/src/download/mod.rs
+++ b/src/download/mod.rs
@@ -6,7 +6,7 @@ use std::{borrow::Cow, fmt};
 use camino::Utf8Path;
 use const_format::formatcp;
 pub use downloader::Downloader;
-pub use file::DownloadedFile;
+pub use file::{DownloadedFile, sha256_digest};
 use reqwest::{Client, ClientBuilder, Response, header::HeaderValue, redirect::Policy};
 use uuid::Uuid;
 use winget_types::installer::VALID_FILE_EXTENSIONS;


### PR DESCRIPTION
In some cases, I've already downloaded a large installer manually, and I want to create a manifest without waiting for komac to redownload it. `komac [new|update] --urls <urls> --files <paths>` analyses existing installer files instead of downloading them. If there are multiple files, they're matched to urls by position eg files[1] must be from urls[1].