### PR TITLE
Analyse Advanced Installer exe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2115,6 +2115,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
+ "sevenz-rust2",
  "sha2 0.11.0",
  "strsim 0.11.1",
  "strum 0.28.0",
@@ -2329,6 +2330,12 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
 
 [[package]]
 name = "lzxd"
@@ -2983,6 +2990,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -3797,6 +3810,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sevenz-rust2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29225600349ef74beda5a9fffb36ac660a24613c0bde9315d0c49be1d51e9c24"
+dependencies = [
+ "aes",
+ "bzip2",
+ "cbc",
+ "crc32fast",
+ "getrandom 0.4.2",
+ "js-sys",
+ "lzma-rust2",
+ "ppmd-rust",
+ "sha2 0.10.9",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 serde_with = "3.18.0"
 serde_yaml = { package = "yaml_serde", version = "0.10.4" }
+sevenz-rust2 = "0.20.2"
 sha2 = "0.11.0"
 strsim = "0.11.1"
 strum = { version = "0.28.0", features = ["derive"] }

--- a/src/analysis/installers/advanced.rs
+++ b/src/analysis/installers/advanced.rs
@@ -1,0 +1,240 @@
+use std::{
+    collections::BTreeSet,
+    io::{self, Cursor, Read, Seek, SeekFrom},
+};
+
+use encoding_rs::UTF_16LE;
+use sevenz_rust2::{ArchiveReader, Password};
+use thiserror::Error;
+use tracing::debug;
+use winget_types::installer::{
+    AppsAndFeaturesEntry, ExpectedReturnCodes, Installer, InstallerReturnCode, InstallerSwitches,
+    InstallerType, ReturnResponse,
+};
+use zerocopy::little_endian::I32 as LE_I32;
+
+use crate::{
+    analysis::{Installers, installers::pe::PE},
+    read::ReadBytesExt,
+};
+
+use super::msi::Msi;
+
+#[derive(Error, Debug)]
+pub enum AdvancedInstallerError {
+    #[error("File is not an Advanced Installer")]
+    NotAdvancedInstallerFile,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+pub struct AdvancedInstaller {
+    installers: Vec<Msi>,
+}
+
+impl AdvancedInstaller {
+    pub fn new<R: Read + Seek>(mut reader: R, pe: &PE) -> Result<Self, AdvancedInstallerError> {
+        let end_offset = pe
+            .optional_header
+            .data_directories
+            .certificate_table()
+            .filter(|dir| dir.virtual_address() != 0)
+            .map(|dir| dir.virtual_address() as u64)
+            .or_else(|| pe.overlay_offset())
+            .unwrap_or_else(|| reader.seek(SeekFrom::End(0)).unwrap_or(0));
+
+        // 11-byte magic before EOF or cert table, padded with trailing nulls to 8-byte boundary
+        let search_start = end_offset.saturating_sub(18);
+        reader.seek(SeekFrom::Start(search_start))?;
+        let mut buf = vec![0u8; (end_offset - search_start) as usize];
+        reader.read_exact(&mut buf)?;
+        let magic_pos = buf
+            .windows(11)
+            .rposition(|w| w == b"ADVINSTSFX\0")
+            .ok_or(AdvancedInstallerError::NotAdvancedInstallerFile)?;
+
+        let footer_offset = search_start + magic_pos as u64 - 60;
+        reader.seek(SeekFrom::Start(footer_offset + 4))?;
+        let num_files = reader.read_t::<LE_I32>()?.get() as usize;
+        reader.seek(SeekFrom::Current(8))?;
+        let files_offset = reader.read_t::<LE_I32>()?.get();
+
+        reader.seek(SeekFrom::Start(files_offset as u64))?;
+        let mut files = Vec::with_capacity(num_files);
+        for _ in 0..num_files {
+            reader.seek(SeekFrom::Current(8))?;
+            let encoding_flag = reader.read_t::<LE_I32>()?.get() as u32;
+            let size = reader.read_t::<LE_I32>()?.get() as u32;
+            let offset = reader.read_t::<LE_I32>()?.get() as u32;
+            let name_chars = reader.read_t::<LE_I32>()?.get() as usize;
+            let mut name_bytes = vec![0u8; name_chars * 2];
+            reader.read_exact(&mut name_bytes)?;
+            let name = UTF_16LE.decode(&name_bytes).0.trim_matches('\0').to_owned();
+            debug!(file = ?name);
+            files.push(File {
+                name,
+                size,
+                offset,
+                encoding_flag,
+            });
+        }
+
+        // TODO are there cases where we should parse this ini?
+        if let Some(ini_file) = files
+            .iter()
+            .rev()
+            .find(|f| f.name.to_ascii_lowercase().ends_with(".ini"))
+            && let Ok(ini_data) = ini_file.read(&mut reader)
+        {
+            debug!(ini = %UTF_16LE.decode(&ini_data).0);
+        }
+
+        let installers = files
+            .iter()
+            .rev()
+            .find(|f| f.name.to_ascii_lowercase().ends_with(".7z"))
+            .and_then(|archive| archive.read(&mut reader).ok())
+            .and_then(|seven_z_data| {
+                let mut msis = Vec::new();
+                ArchiveReader::new(Cursor::new(&seven_z_data), Password::empty())
+                    .ok()?
+                    .for_each_entries(|entry, reader| {
+                        debug!(seven_z_file = ?entry.name());
+                        let mut buf = Vec::new();
+                        if reader.read_to_end(&mut buf).is_ok()
+                            && let Ok(msi) = Msi::new(Cursor::new(buf))
+                        {
+                            msis.push(msi);
+                        }
+                        Ok(true)
+                    })
+                    .ok()?;
+                (!msis.is_empty()).then_some(msis)
+            })
+            .unwrap_or_else(|| {
+                files
+                    .iter()
+                    .filter(|f| f.name.to_ascii_lowercase().ends_with(".msi"))
+                    .filter_map(|msi_file| msi_file.read(&mut reader).ok())
+                    .filter_map(|msi_data| Msi::new(Cursor::new(msi_data)).ok())
+                    .collect()
+            });
+
+        if installers.is_empty() {
+            tracing::warn!(
+                "Detected Advanced Installer with no MSI files. Please open an issue: https://github.com/russellbanks/Komac/issues/new?template=bug.yml"
+            );
+            return Err(AdvancedInstallerError::NotAdvancedInstallerFile);
+        }
+
+        Ok(Self { installers })
+    }
+}
+
+impl Installers for AdvancedInstaller {
+    fn installers(&self) -> Vec<Installer> {
+        self.installers
+            .iter()
+            .map(|msi| {
+                let mut installer = msi.installers().into_iter().next().unwrap_or_default();
+                installer.r#type = Some(InstallerType::Exe);
+
+                // https://www.advancedinstaller.com/user-guide/exe-setup-file.html#proprietary-command-line-switches-for-the-exe-setup
+                installer.switches = InstallerSwitches::builder()
+                    .silent("/exenoui /quiet".parse().unwrap())
+                    .silent_with_progress("/exenoui /passive".parse().unwrap())
+                    .install_location("APPDIR=\"<INSTALLPATH>\"".parse().unwrap())
+                    .log("/log \"<LOGPATH>\"".parse().unwrap())
+                    .custom(
+                        installer
+                            .switches
+                            .custom()
+                            .map(|s| format!("/norestart {}", s))
+                            .unwrap_or_else(|| "/norestart".to_string())
+                            .parse()
+                            .unwrap(),
+                    )
+                    .build();
+
+                // https://www.advancedinstaller.com/user-guide/exe-setup-file.html#return-code
+                installer.expected_return_codes = expected_return_codes();
+
+                // If the MSI is hidden, there's another ARP entry that shares some values
+                if msi
+                    .property_table
+                    .iter()
+                    .any(|(key, value)| key == "ARPSYSTEMCOMPONENT" && value == "1")
+                    && let Some(template) = installer.apps_and_features_entries.iter().next()
+                {
+                    let product_code = format!(
+                        "{} {}",
+                        template.display_name().unwrap_or_default(),
+                        template.display_version().unwrap()
+                    );
+                    installer.product_code = Some(product_code.clone());
+                    installer.apps_and_features_entries = AppsAndFeaturesEntry::builder()
+                        .maybe_display_name(template.display_name())
+                        .maybe_display_version(template.display_version().cloned())
+                        .maybe_publisher(template.publisher())
+                        .maybe_product_code(Some(product_code))
+                        .build()
+                        .into()
+                }
+
+                installer
+            })
+            .collect()
+    }
+}
+
+fn expected_return_codes() -> BTreeSet<ExpectedReturnCodes> {
+    use ReturnResponse::*;
+    [
+        (-1, CancelledByUser),
+        (1, InvalidParameter),
+        (87, InvalidParameter),
+        (1601, ContactSupport),
+        (1602, CancelledByUser),
+        (1618, InstallInProgress),
+        (1623, SystemNotSupported),
+        (1625, BlockedByPolicy),
+        (1628, InvalidParameter),
+        (1633, SystemNotSupported),
+        (1638, AlreadyInstalled),
+        (1639, InvalidParameter),
+        (1640, BlockedByPolicy),
+        (1641, RebootInitiated),
+        (1643, BlockedByPolicy),
+        (1644, BlockedByPolicy),
+        (1649, BlockedByPolicy),
+        (1650, InvalidParameter),
+        (1654, SystemNotSupported),
+        (3010, RebootRequiredToFinish),
+    ]
+    .into_iter()
+    .map(|(code, response)| ExpectedReturnCodes {
+        installer_return_code: InstallerReturnCode::new(code),
+        return_response: response,
+        return_response_url: None,
+    })
+    .collect()
+}
+
+struct File {
+    name: String,
+    size: u32,
+    offset: u32,
+    encoding_flag: u32,
+}
+
+impl File {
+    fn read<R: Read + Seek>(&self, reader: &mut R) -> std::io::Result<Vec<u8>> {
+        reader.seek(SeekFrom::Start(self.offset.into()))?;
+        let mut data = vec![0u8; self.size as usize];
+        reader.read_exact(&mut data)?;
+        if self.encoding_flag == 2 {
+            data.iter_mut().take(0x200).for_each(|b| *b ^= 0xFF);
+        }
+        Ok(data)
+    }
+}

--- a/src/analysis/installers/advanced/file_entry.rs
+++ b/src/analysis/installers/advanced/file_entry.rs
@@ -1,0 +1,114 @@
+use std::{
+    fmt, io,
+    io::{Read, Seek, SeekFrom},
+};
+
+use zerocopy::{FromBytes, Immutable, KnownLayout, LE, U32};
+
+#[derive(Clone, Copy, FromBytes, KnownLayout, Immutable)]
+#[repr(C)]
+pub struct FileEntry {
+    /// * [0, 3] = INI
+    /// * [1, 0] = MSI
+    /// * [7, 1], [1, 1] = CAB
+    /// * [5, 11], [5, 12] = DLL
+    /// * [2, 8] = decoder.dll
+    /// * [3, 7] = 7Z
+    /// * [8, 6] = FILES.7z
+    /// * [1, 13] = AIUI
+    /// * [100, 8] = vc_redist.x64.exe
+    /// * [101, 8] = vc_redist.x86.exe
+    /// * [102, 8] = ndp48-web.exe
+    /// * [103, 8] = MicrosoftEdgeWebview2Setup.exe
+    r#type: [U32<LE>; 2],
+
+    xor_flag: U32<LE>,
+
+    /// The file's size in bytes.
+    size: U32<LE>,
+
+    /// The file's offset relative to the start of the SFX stub.
+    offset: U32<LE>,
+
+    /// Returns the size of the name in UTF-16LE characters.
+    name_size: U32<LE>,
+}
+
+impl FileEntry {
+    pub const fn r#type(&self) -> [u32; 2] {
+        [self.r#type[0].get(), self.r#type[1].get()]
+    }
+
+    /// Returns the XOR flag.
+    #[inline]
+    pub const fn xor_flag(&self) -> u32 {
+        self.xor_flag.get()
+    }
+
+    /// Returns the file's size in bytes.
+    #[inline]
+    pub const fn size(&self) -> u32 {
+        self.size.get()
+    }
+
+    /// Returns the offset of the file, relative to the start of the SFX stub.
+    #[inline]
+    pub const fn offset(&self) -> u32 {
+        self.offset.get()
+    }
+
+    /// Returns the size of the name in UTF-16LE characters.
+    #[inline]
+    pub const fn name_size(&self) -> u32 {
+        self.name_size.get()
+    }
+
+    /// Returns `true` if the file entry is an `msi` file.
+    pub fn is_msi(&self) -> bool {
+        const MSI: [U32<LE>; 2] = [U32::new(1), U32::ZERO];
+
+        self.r#type == MSI
+    }
+
+    /// Returns `true` if the file entry is an `ini` file.
+    pub fn is_ini(&self) -> bool {
+        const INI: [U32<LE>; 2] = [U32::ZERO, U32::new(3)];
+
+        self.r#type == INI
+    }
+
+    /// Returns `true` if the file is a `7z` file.
+    pub fn is_7z(&self) -> bool {
+        const SEVEN_Z: [U32<LE>; 2] = [U32::new(3), U32::new(7)];
+
+        self.r#type == SEVEN_Z
+    }
+
+    pub fn read_file<R>(&self, reader: &mut R) -> io::Result<Vec<u8>>
+    where
+        R: Read + Seek,
+    {
+        reader.seek(SeekFrom::Start(self.offset().into()))?;
+
+        let mut data = vec![0; self.size() as usize];
+        reader.read_exact(&mut data)?;
+
+        if self.xor_flag() == 2 {
+            data.iter_mut().take(0x200).for_each(|byte| *byte ^= 0xFF);
+        }
+
+        Ok(data)
+    }
+}
+
+impl fmt::Debug for FileEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FileEntry")
+            .field("type", &self.r#type())
+            .field("xor_flag", &self.xor_flag())
+            .field("size", &self.size())
+            .field("offset", &self.offset())
+            .field("name_size", &self.name_size())
+            .finish()
+    }
+}

--- a/src/analysis/installers/advanced/footer.rs
+++ b/src/analysis/installers/advanced/footer.rs
@@ -1,0 +1,142 @@
+use std::{
+    fmt,
+    io::{Read, Seek, SeekFrom},
+    mem::offset_of,
+};
+
+use zerocopy::{FromBytes, Immutable, KnownLayout, LE, U32, Unaligned};
+
+use super::AdvancedInstallerError;
+use crate::read::ReadBytesExt;
+
+/// Advanced Installer Footer.
+///
+/// Sources:
+/// * <https://github.com/SabreTools/SabreTools.Serialization/blob/main/SabreTools.Data.Models/AdvancedInstaller/Footer.cs>
+/// * <https://gist.github.com/KasparNagu/9ee02cb62d81d9e4c7a833518a710d6e>
+/// * <https://gist.github.com/cw2k/2b2163c422183b884b7405bc0e09dfb2>
+#[derive(Clone, Copy, FromBytes, KnownLayout, Immutable, Unaligned)]
+#[repr(C)]
+pub struct Footer {
+    reserved: U32<LE>,
+
+    /// Absolute offset of the footer within the EXE.
+    offset: U32<LE>,
+
+    num_files: U32<LE>,
+
+    /// 100
+    version: U32<LE>,
+
+    info_offset: U32<LE>,
+
+    table_pointer: U32<LE>,
+
+    file_data_start: U32<LE>,
+
+    hex_string: [u8; 32],
+
+    unknown: U32<LE>,
+
+    /// "ADVINSTSFX"
+    signature: [u8; 10],
+}
+
+impl Footer {
+    pub const SIGNATURE: &[u8; 10] = b"ADVINSTSFX";
+
+    pub const SIGNATURE_OFFSET: usize = offset_of!(Footer, signature);
+
+    pub fn find<R: Read + Seek>(reader: &mut R) -> Result<Self, AdvancedInstallerError> {
+        const SEARCH_BLOCK_SIZE: usize = 16 * 1024;
+
+        let search_start = reader
+            .seek(SeekFrom::End(-(SEARCH_BLOCK_SIZE as i64)))
+            .map_err(|_| AdvancedInstallerError::NotAdvancedInstallerFile)?;
+
+        let mut buf = [0; SEARCH_BLOCK_SIZE];
+        reader.read_exact(&mut buf)?;
+
+        let signature_pos = buf
+            .array_windows()
+            .rposition(|window| window == Footer::SIGNATURE)
+            .ok_or(AdvancedInstallerError::NotAdvancedInstallerFile)?;
+
+        let footer_offset = search_start + signature_pos as u64 - Footer::SIGNATURE_OFFSET as u64;
+        reader.seek(SeekFrom::Start(footer_offset))?;
+
+        reader.read_t::<Self>().map_err(AdvancedInstallerError::Io)
+    }
+
+    /// Returns the absolute offset of the footer within the EXE.
+    #[inline]
+    pub const fn offset(&self) -> u32 {
+        self.offset.get()
+    }
+
+    /// Returns the number of files in the installer.
+    #[inline]
+    pub const fn num_files(&self) -> u32 {
+        self.num_files.get()
+    }
+
+    /// Returns the Advanced Installer version.
+    #[inline]
+    pub const fn version(&self) -> u32 {
+        self.version.get()
+    }
+
+    #[inline]
+    pub const fn info_offset(&self) -> u32 {
+        self.info_offset.get()
+    }
+
+    #[inline]
+    pub const fn table_pointer(&self) -> u32 {
+        self.table_pointer.get()
+    }
+
+    #[inline]
+    pub const fn file_data_start(&self) -> u32 {
+        self.file_data_start.get()
+    }
+}
+
+impl fmt::Debug for Footer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Footer")
+            .field("unknown", &self.reserved.get())
+            .field("offset", &self.offset())
+            .field("num_files", &self.num_files())
+            .field("version", &self.version())
+            .field("info_offset", &self.info_offset())
+            .field("table_pointer", &self.table_pointer())
+            .field("file_data_start", &self.file_data_start())
+            .field("hex_string", &String::from_utf8_lossy(&self.hex_string))
+            .field("unknown", &self.unknown.get())
+            .field("signature", &String::from_utf8_lossy(&self.signature))
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::mem::offset_of;
+
+    use super::Footer;
+
+    #[test]
+    fn size() {
+        assert_eq!(size_of::<Footer>(), 74);
+    }
+
+    #[test]
+    fn alignment() {
+        assert_eq!(align_of::<Footer>(), 1);
+    }
+
+    #[test]
+    fn signature_offset() {
+        assert_eq!(Footer::SIGNATURE_OFFSET, 64);
+    }
+}

--- a/src/analysis/installers/advanced/mod.rs
+++ b/src/analysis/installers/advanced/mod.rs
@@ -1,24 +1,27 @@
+mod file_entry;
+mod footer;
+mod named_file_entry;
+
 use std::{
     collections::BTreeSet,
     io::{self, Cursor, Read, Seek, SeekFrom},
 };
 
 use encoding_rs::UTF_16LE;
+use file_entry::FileEntry;
+use footer::Footer;
+use named_file_entry::NamedFileEntry;
 use sevenz_rust2::{ArchiveReader, Password};
 use thiserror::Error;
-use tracing::debug;
+use tracing::{debug, warn};
 use winget_types::installer::{
     AppsAndFeaturesEntry, ExpectedReturnCodes, Installer, InstallerReturnCode, InstallerSwitches,
     InstallerType, ReturnResponse,
 };
-use zerocopy::little_endian::I32 as LE_I32;
-
-use crate::{
-    analysis::{Installers, installers::pe::PE},
-    read::ReadBytesExt,
-};
+use zerocopy::IntoBytes;
 
 use super::msi::Msi;
+use crate::{analysis::Installers, read::ReadBytesExt};
 
 #[derive(Error, Debug)]
 pub enum AdvancedInstallerError {
@@ -33,69 +36,38 @@ pub struct AdvancedInstaller {
 }
 
 impl AdvancedInstaller {
-    pub fn new<R: Read + Seek>(mut reader: R, pe: &PE) -> Result<Self, AdvancedInstallerError> {
-        let end_offset = pe
-            .optional_header
-            .data_directories
-            .certificate_table()
-            .filter(|dir| dir.virtual_address() != 0)
-            .map(|dir| dir.virtual_address() as u64)
-            .or_else(|| pe.overlay_offset())
-            .unwrap_or_else(|| reader.seek(SeekFrom::End(0)).unwrap_or(0));
+    pub fn new<R: Read + Seek>(mut reader: R) -> Result<Self, AdvancedInstallerError> {
+        let footer = Footer::find(&mut reader)?;
 
-        // 11-byte magic before EOF or cert table, padded with trailing nulls to 8-byte boundary
-        let search_start = end_offset.saturating_sub(18);
-        reader.seek(SeekFrom::Start(search_start))?;
-        let mut buf = vec![0u8; (end_offset - search_start) as usize];
-        reader.read_exact(&mut buf)?;
-        let magic_pos = buf
-            .windows(11)
-            .rposition(|w| w == b"ADVINSTSFX\0")
-            .ok_or(AdvancedInstallerError::NotAdvancedInstallerFile)?;
+        debug!(?footer);
 
-        let footer_offset = search_start + magic_pos as u64 - 60;
-        reader.seek(SeekFrom::Start(footer_offset + 4))?;
-        let num_files = reader.read_t::<LE_I32>()?.get() as usize;
-        reader.seek(SeekFrom::Current(8))?;
-        let files_offset = reader.read_t::<LE_I32>()?.get();
+        reader.seek(SeekFrom::Start(footer.table_pointer().into()))?;
 
-        reader.seek(SeekFrom::Start(files_offset as u64))?;
-        let mut files = Vec::with_capacity(num_files);
-        for _ in 0..num_files {
-            reader.seek(SeekFrom::Current(8))?;
-            let encoding_flag = reader.read_t::<LE_I32>()?.get() as u32;
-            let size = reader.read_t::<LE_I32>()?.get() as u32;
-            let offset = reader.read_t::<LE_I32>()?.get() as u32;
-            let name_chars = reader.read_t::<LE_I32>()?.get() as usize;
-            let mut name_bytes = vec![0u8; name_chars * 2];
-            reader.read_exact(&mut name_bytes)?;
-            let name = UTF_16LE.decode(&name_bytes).0.trim_matches('\0').to_owned();
-            debug!(file = ?name);
-            files.push(File {
-                name,
-                size,
-                offset,
-                encoding_flag,
-            });
+        let mut files = Vec::with_capacity(footer.num_files() as usize);
+        for _ in 0..footer.num_files() {
+            let file_entry = reader.read_t::<FileEntry>()?;
+
+            let mut name_bytes = vec![0_u16; file_entry.name_size() as usize];
+            reader.read_exact(name_bytes.as_mut_bytes())?;
+            let name = UTF_16LE.decode(name_bytes.as_bytes()).0;
+
+            let named_file_entry = NamedFileEntry::new(file_entry, name);
+            debug!(?named_file_entry);
+            files.push(named_file_entry);
         }
 
-        // TODO are there cases where we should parse this ini?
-        if let Some(ini_file) = files
-            .iter()
-            .rev()
-            .find(|f| f.name.to_ascii_lowercase().ends_with(".ini"))
-            && let Ok(ini_data) = ini_file.read(&mut reader)
+        if let Some(ini_file) = files.iter().rfind(|entry| entry.is_ini())
+            && let Ok(ini_data) = ini_file.read_file(&mut reader)
         {
             debug!(ini = %UTF_16LE.decode(&ini_data).0);
         }
 
         let installers = files
             .iter()
-            .rev()
-            .find(|f| f.name.to_ascii_lowercase().ends_with(".7z"))
-            .and_then(|archive| archive.read(&mut reader).ok())
+            .rfind(|entry| entry.is_7z())
+            .and_then(|archive| archive.read_file(&mut reader).ok())
             .and_then(|seven_z_data| {
-                let mut msis = Vec::new();
+                let mut msi_files = Vec::new();
                 ArchiveReader::new(Cursor::new(&seven_z_data), Password::empty())
                     .ok()?
                     .for_each_entries(|entry, reader| {
@@ -104,26 +76,27 @@ impl AdvancedInstaller {
                         if reader.read_to_end(&mut buf).is_ok()
                             && let Ok(msi) = Msi::new(Cursor::new(buf))
                         {
-                            msis.push(msi);
+                            msi_files.push(msi);
                         }
                         Ok(true)
                     })
                     .ok()?;
-                (!msis.is_empty()).then_some(msis)
+                (!msi_files.is_empty()).then_some(msi_files)
             })
             .unwrap_or_else(|| {
                 files
                     .iter()
-                    .filter(|f| f.name.to_ascii_lowercase().ends_with(".msi"))
-                    .filter_map(|msi_file| msi_file.read(&mut reader).ok())
+                    .filter(|entry| entry.is_msi())
+                    .filter_map(|msi_file| msi_file.read_file(&mut reader).ok())
                     .filter_map(|msi_data| Msi::new(Cursor::new(msi_data)).ok())
                     .collect()
             });
 
         if installers.is_empty() {
-            tracing::warn!(
+            warn!(
                 "Detected Advanced Installer with no MSI files. Please open an issue: https://github.com/russellbanks/Komac/issues/new?template=bug.yml"
             );
+
             return Err(AdvancedInstallerError::NotAdvancedInstallerFile);
         }
 
@@ -143,16 +116,18 @@ impl Installers for AdvancedInstaller {
                 installer.switches = InstallerSwitches::builder()
                     .silent("/exenoui /quiet".parse().unwrap())
                     .silent_with_progress("/exenoui /passive".parse().unwrap())
-                    .install_location("APPDIR=\"<INSTALLPATH>\"".parse().unwrap())
-                    .log("/log \"<LOGPATH>\"".parse().unwrap())
+                    .install_location(r#"APPDIR="<INSTALLPATH>""#.parse().unwrap())
+                    .log(r#"/log "<LOGPATH>""#.parse().unwrap())
                     .custom(
                         installer
                             .switches
                             .custom()
-                            .map(|s| format!("/norestart {}", s))
-                            .unwrap_or_else(|| "/norestart".to_string())
-                            .parse()
-                            .unwrap(),
+                            .cloned()
+                            .map(|mut custom| {
+                                custom.push("/norestart");
+                                custom
+                            })
+                            .unwrap_or_else(|| "/norestart".parse().unwrap()),
                     )
                     .build();
 
@@ -189,6 +164,7 @@ impl Installers for AdvancedInstaller {
 
 fn expected_return_codes() -> BTreeSet<ExpectedReturnCodes> {
     use ReturnResponse::*;
+
     [
         (-1, CancelledByUser),
         (1, InvalidParameter),
@@ -218,23 +194,4 @@ fn expected_return_codes() -> BTreeSet<ExpectedReturnCodes> {
         return_response_url: None,
     })
     .collect()
-}
-
-struct File {
-    name: String,
-    size: u32,
-    offset: u32,
-    encoding_flag: u32,
-}
-
-impl File {
-    fn read<R: Read + Seek>(&self, reader: &mut R) -> std::io::Result<Vec<u8>> {
-        reader.seek(SeekFrom::Start(self.offset.into()))?;
-        let mut data = vec![0u8; self.size as usize];
-        reader.read_exact(&mut data)?;
-        if self.encoding_flag == 2 {
-            data.iter_mut().take(0x200).for_each(|b| *b ^= 0xFF);
-        }
-        Ok(data)
-    }
 }

--- a/src/analysis/installers/advanced/named_file_entry.rs
+++ b/src/analysis/installers/advanced/named_file_entry.rs
@@ -1,0 +1,94 @@
+use std::{
+    fmt, io,
+    io::{Read, Seek},
+};
+
+use super::file_entry::FileEntry;
+
+#[derive(Clone)]
+pub struct NamedFileEntry {
+    file_entry: FileEntry,
+    name: String,
+}
+
+impl NamedFileEntry {
+    /// Creates a new [`NamedFileEntry`] from a [`FileEntry`] and a name.
+    pub fn new<S>(file_entry: FileEntry, name: S) -> Self
+    where
+        S: Into<String>,
+    {
+        Self {
+            file_entry,
+            name: name.into(),
+        }
+    }
+
+    #[inline]
+    pub const fn r#type(&self) -> [u32; 2] {
+        self.file_entry.r#type()
+    }
+
+    #[inline]
+    pub const fn xor_flag(&self) -> u32 {
+        self.file_entry.xor_flag()
+    }
+
+    #[inline]
+    pub const fn size(&self) -> u32 {
+        self.file_entry.size()
+    }
+
+    #[inline]
+    pub const fn offset(&self) -> u32 {
+        self.file_entry.offset()
+    }
+
+    /// Returns the size of the name in UTF-16LE characters.
+    #[inline]
+    pub const fn name_size(&self) -> u32 {
+        self.file_entry.name_size()
+    }
+
+    #[inline]
+    pub const fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    /// Returns `true` if the file entry is an `msi` file.
+    #[inline]
+    pub fn is_msi(&self) -> bool {
+        self.file_entry.is_msi()
+    }
+
+    /// Returns `true` if the file is an `ini` file.
+    #[inline]
+    pub fn is_ini(&self) -> bool {
+        self.file_entry.is_ini()
+    }
+
+    /// Returns `true` if the file is a `7z` file.
+    #[inline]
+    pub fn is_7z(&self) -> bool {
+        self.file_entry.is_7z()
+    }
+
+    pub fn read_file<R>(&self, reader: &mut R) -> io::Result<Vec<u8>>
+    where
+        R: Read + Seek,
+    {
+        self.file_entry.read_file(reader)
+    }
+}
+
+impl fmt::Debug for NamedFileEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("NamedFileEntry")
+            .field("type", &self.r#type())
+            .field("xor_flag", &self.xor_flag())
+            .field("size", &self.size())
+            .field("offset", &self.offset())
+            .field("name_size", &self.name_size())
+            .field("name", &self.name())
+            .finish()
+    }
+}

--- a/src/analysis/installers/exe.rs
+++ b/src/analysis/installers/exe.rs
@@ -4,9 +4,10 @@ use color_eyre::Result;
 use inno::{Inno, error::InnoError};
 use winget_types::installer::{Installer, InstallerType};
 
-use super::{super::Installers, Burn, Nsis, Squirrel};
+use super::{super::Installers, AdvancedInstaller, Burn, Nsis, Squirrel};
 use crate::{
     analysis::installers::{
+        advanced::AdvancedInstallerError,
         burn::BurnError,
         nsis::NsisError,
         pe::{PE, VSVersionInfo},
@@ -27,6 +28,7 @@ pub struct Exe {
 }
 
 pub enum ExeType {
+    AdvancedInstaller(AdvancedInstaller),
     Burn(Box<Burn>),
     Inno(Box<Inno>),
     Nsis(Nsis),
@@ -55,6 +57,19 @@ impl Exe {
             .as_mut()
             .and_then(|table| table.swap_remove("CompanyName"))
             .map(str::to_owned);
+
+        match AdvancedInstaller::new(&mut reader, &pe) {
+            Ok(advanced) => {
+                return Ok(Self {
+                    r#type: ExeType::AdvancedInstaller(advanced),
+                    legal_copyright,
+                    product_name,
+                    company_name,
+                });
+            }
+            Err(AdvancedInstallerError::NotAdvancedInstallerFile) => {}
+            Err(error) => return Err(error.into()),
+        }
 
         match Burn::new(&mut reader, &pe) {
             Ok(burn) => {
@@ -137,6 +152,7 @@ impl Exe {
 impl Installers for Exe {
     fn installers(&self) -> Vec<Installer> {
         match &self.r#type {
+            ExeType::AdvancedInstaller(advanced) => advanced.installers(),
             ExeType::Burn(burn) => burn.installers(),
             ExeType::Inno(inno) => inno.installers(),
             ExeType::Nsis(nsis) => nsis.installers(),

--- a/src/analysis/installers/exe.rs
+++ b/src/analysis/installers/exe.rs
@@ -58,7 +58,7 @@ impl Exe {
             .and_then(|table| table.swap_remove("CompanyName"))
             .map(str::to_owned);
 
-        match AdvancedInstaller::new(&mut reader, &pe) {
+        match AdvancedInstaller::new(&mut reader) {
             Ok(advanced) => {
                 return Ok(Self {
                     r#type: ExeType::AdvancedInstaller(advanced),

--- a/src/analysis/installers/mod.rs
+++ b/src/analysis/installers/mod.rs
@@ -1,3 +1,4 @@
+mod advanced;
 pub mod burn;
 mod exe;
 pub mod inno;
@@ -9,6 +10,7 @@ pub mod squirrel;
 pub mod utils;
 mod zip;
 
+pub use advanced::AdvancedInstaller;
 pub use burn::Burn;
 pub use exe::Exe;
 pub use msi::Msi;

--- a/src/analysis/installers/pe/mod.rs
+++ b/src/analysis/installers/pe/mod.rs
@@ -116,6 +116,11 @@ impl PE {
         self.optional_header.data_directories.resource_table()
     }
 
+    #[inline]
+    pub fn certificate_table(&self) -> Option<&DataDirectory> {
+        self.optional_header.data_directories.certificate_table()
+    }
+
     pub fn find_resource_by_name<R>(&self, mut reader: R, name: &str) -> io::Result<Take<R>>
     where
         R: Read + Seek,


### PR DESCRIPTION
There's [quite a few Advanced Installer packages](https://github.com/search?q=repo%3Amicrosoft%2Fwinget-pkgs+%22exe+%23+Advanced+Installer%22&type=code) on winget-pkgs, so I thought this was worth submitting. I've tested it against a dozen or so winget-pkgs cases.

The [format](https://www.advancedinstaller.com/user-guide/exe-setup-file.html) is pretty simple. It's all in the overlay, using a footer with file count and an offset of a list of files, plus simple file headers and optional XOR encoding. One of the files is a 7z archive with MSI(s) that are executed, so I've just located+parsed the MSIs. There's some custom args and return codes for the exe too