### PR TITLE
Analyse Squirrel.Windows and Velopack

### DIFF
--- a/src/analysis/installers/burn/mod.rs
+++ b/src/analysis/installers/burn/mod.rs
@@ -71,39 +71,33 @@ impl Burn {
             let mut resource_directory = ResourceDirectory::new(section_reader)?;
 
             let _rc_data = resource_directory
-                .find_rc_data()
-                .map_err(|_| BurnError::NotBurnFile);
+                .navigate_to_rc_data()
+                .map_err(|_| BurnError::NotBurnFile)?;
 
-            let msi_entry = resource_directory
-                .find_name_entry("MSI")
-                .ok_or(BurnError::NotBurnFile)?;
+            let msi_directory_table =
+                resource_directory.navigate_to_directory_table_by_name("MSI")?;
 
-            let msi_directory_table = msi_entry
-                .data(&mut resource_directory)?
-                .table()
-                .ok_or(BurnError::NotBurnFile)?;
-
-            return if let Some(msi_directory) = msi_directory_table.entries().next() {
-                let msi_data_entry_offset = msi_directory.file_offset(resource_directory_offset);
-                reader.seek(SeekFrom::Start(msi_data_entry_offset.into()))?;
-
-                let msi_data_entry = reader.read_t::<ImageResourceDataEntry>()?;
-                let msi_offset = pe
-                    .section_table
-                    .to_file_offset(msi_data_entry.offset_to_data())?;
-
-                // Installers built with the Java Development Kit embed an MSI resource
-                reader.seek(SeekFrom::Start(msi_offset.into()))?;
-                let msi_reader = reader.take(msi_data_entry.size().into());
-                let msi = Msi::new(msi_reader)?;
-                Ok(Self {
-                    architecture: msi.architecture,
-                    manifest: None,
-                    msi: Some(msi),
-                })
-            } else {
-                Err(BurnError::NotBurnFile)
+            let Some(msi_directory) = msi_directory_table.id_entries().next() else {
+                return Err(BurnError::NotBurnFile);
             };
+
+            let msi_data_entry_offset = msi_directory.file_offset(resource_directory_offset);
+            reader.seek(SeekFrom::Start(msi_data_entry_offset.into()))?;
+
+            let msi_data_entry = reader.read_t::<ImageResourceDataEntry>()?;
+            let msi_offset = pe
+                .section_table
+                .to_file_offset(msi_data_entry.offset_to_data())?;
+
+            // Installers built with the Java Development Kit embed an MSI resource
+            reader.seek(SeekFrom::Start(msi_offset.into()))?;
+            let msi_reader = reader.take(msi_data_entry.size().into());
+            let msi = Msi::new(msi_reader)?;
+            return Ok(Self {
+                architecture: msi.architecture,
+                manifest: None,
+                msi: Some(msi),
+            });
         };
 
         // Seek to and read wix burn stub

--- a/src/analysis/installers/exe.rs
+++ b/src/analysis/installers/exe.rs
@@ -4,12 +4,13 @@ use color_eyre::Result;
 use inno::{Inno, error::InnoError};
 use winget_types::installer::{Installer, InstallerType};
 
-use super::{super::Installers, Burn, Nsis};
+use super::{super::Installers, Burn, Nsis, Squirrel};
 use crate::{
     analysis::installers::{
         burn::BurnError,
         nsis::NsisError,
         pe::{PE, VSVersionInfo},
+        squirrel::SquirrelError,
     },
     traits::IntoWingetArchitecture,
 };
@@ -29,6 +30,7 @@ pub enum ExeType {
     Burn(Box<Burn>),
     Inno(Box<Inno>),
     Nsis(Nsis),
+    Squirrel(Squirrel),
     Generic(Box<Installer>),
 }
 
@@ -93,6 +95,19 @@ impl Exe {
             Err(error) => return Err(error.into()),
         }
 
+        match Squirrel::new(&mut reader, &pe) {
+            Ok(squirrel) => {
+                return Ok(Self {
+                    r#type: ExeType::Squirrel(squirrel),
+                    legal_copyright,
+                    product_name,
+                    company_name,
+                });
+            }
+            Err(SquirrelError::NotSquirrelFile) => {}
+            Err(error) => return Err(error.into()),
+        }
+
         Ok(Self {
             r#type: ExeType::Generic(Box::new(Installer {
                 architecture: pe.winget_architecture(),
@@ -125,6 +140,7 @@ impl Installers for Exe {
             ExeType::Burn(burn) => burn.installers(),
             ExeType::Inno(inno) => inno.installers(),
             ExeType::Nsis(nsis) => nsis.installers(),
+            ExeType::Squirrel(squirrel) => squirrel.installers(),
             ExeType::Generic(installer) => vec![*installer.clone()],
         }
     }

--- a/src/analysis/installers/mod.rs
+++ b/src/analysis/installers/mod.rs
@@ -5,6 +5,7 @@ mod msi;
 pub mod msix_family;
 pub mod nsis;
 pub mod pe;
+pub mod squirrel;
 pub mod utils;
 mod zip;
 
@@ -12,4 +13,5 @@ pub use burn::Burn;
 pub use exe::Exe;
 pub use msi::Msi;
 pub use nsis::Nsis;
+pub use squirrel::Squirrel;
 pub use zip::Zip;

--- a/src/analysis/installers/nsis/mod.rs
+++ b/src/analysis/installers/nsis/mod.rs
@@ -33,7 +33,7 @@ use winget_types::{
         Installer, InstallerType, Scope,
     },
 };
-use zerocopy::{FromBytes, LE};
+use zerocopy::FromBytes;
 
 use super::{
     super::extensions::EXE,
@@ -46,12 +46,11 @@ use super::{
             flags::CommonHeaderFlags,
         },
     },
-    pe::PE,
+    pe::{PE, utils::machine_from_exe_reader},
     utils::{LzmaStreamHeader, RELATIVE_PROGRAM_FILES_64},
 };
 use crate::{
     analysis::Installers,
-    read::ReadBytesExt,
     traits::{FromMachine, IntoWingetArchitecture},
 };
 
@@ -215,28 +214,12 @@ impl Nsis {
                             decoder
                         };
 
-                        let mut void = io::sink();
-
                         if is_solid {
                             // Seek to file
-                            io::copy(&mut decoder.by_ref().take(position), &mut void).ok()?;
+                            io::copy(&mut decoder.by_ref().take(position), &mut io::sink()).ok()?;
                         }
 
-                        // Seek to COFF header offset inside exe
-                        io::copy(&mut decoder.by_ref().take(0x3C), &mut void).ok()?;
-
-                        let coff_offset = decoder.read_u32::<LE>().ok()?;
-
-                        // Seek to machine value
-                        io::copy(
-                            &mut decoder
-                                .by_ref()
-                                .take(u64::from(coff_offset.checked_sub(0x3C)?)),
-                            &mut void,
-                        )
-                        .ok()?;
-
-                        let machine = decoder.read_u16::<LE>().ok()?;
+                        let machine = machine_from_exe_reader(decoder).ok()?;
                         Some(Architecture::from_machine(machine))
                     })
             });

--- a/src/analysis/installers/pe/dos/header.rs
+++ b/src/analysis/installers/pe/dos/header.rs
@@ -117,7 +117,7 @@ pub struct DosHeader {
     reserved2: [U16<LittleEndian>; 10],
 
     #[doc(alias("e_lfanew"))]
-    pe_pointer: U32<LittleEndian>,
+    pub(crate) pe_pointer: U32<LittleEndian>,
 }
 
 impl DosHeader {

--- a/src/analysis/installers/pe/mod.rs
+++ b/src/analysis/installers/pe/mod.rs
@@ -6,11 +6,12 @@ pub mod optional_header;
 pub mod resource;
 mod section_table;
 mod signature;
+pub mod utils;
 pub mod vs_version_info;
 
 use std::{
     io,
-    io::{Error, Read, Seek, SeekFrom},
+    io::{Error, Read, Seek, SeekFrom, Take},
 };
 
 pub use coff::CoffHeader;
@@ -23,7 +24,7 @@ pub use vs_version_info::VSVersionInfo;
 use crate::{
     analysis::installers::pe::{
         optional_header::DataDirectory,
-        resource::{ImageResourceDataEntry, ResourceDirectory, SectionReader},
+        resource::{ImageResourceDataEntry, ResourceDirectory, ResourceIter, SectionReader},
     },
     read::ReadBytesExt,
 };
@@ -68,6 +69,17 @@ impl PE {
         })
     }
 
+    pub fn resources<R: Read + Seek>(&self, reader: R) -> io::Result<ResourceIter<R>> {
+        let section_reader = self
+            .resource_table()
+            .ok_or_else(|| Error::other("No resource table"))?
+            .section_reader(reader, &self.section_table)?;
+
+        let resource_directory = ResourceDirectory::new(section_reader)?;
+
+        Ok(ResourceIter::new(resource_directory))
+    }
+
     pub fn find_section(&self, name: [u8; 8]) -> Option<&SectionHeader> {
         self.section_table
             .sections()
@@ -104,6 +116,23 @@ impl PE {
         self.optional_header.data_directories.resource_table()
     }
 
+    pub fn find_resource_by_name<R>(&self, mut reader: R, name: &str) -> io::Result<Take<R>>
+    where
+        R: Read + Seek,
+    {
+        let resource = self
+            .resources(&mut reader)?
+            .find(|resource| resource.name() == Some(name))
+            .ok_or_else(|| Error::other(format!("Resource not found: {name}")))?;
+
+        let resource_offset = self
+            .section_table
+            .to_file_offset(resource.offset_to_data())?;
+
+        reader.seek(SeekFrom::Start(resource_offset.into()))?;
+        Ok(reader.take(resource.size().into()))
+    }
+
     pub fn vs_version_info<R>(&self, mut reader: R) -> io::Result<Vec<u8>>
     where
         R: Read + Seek,
@@ -123,11 +152,10 @@ impl PE {
 
         let mut resource_directory = ResourceDirectory::new(section_reader)?;
 
-        let _version_info = resource_directory.find_version_info()?;
+        let directory_table = resource_directory.navigate_to_version_info()?;
 
-        let version_entry = resource_directory
-            .current_directory_table()
-            .entries()
+        let version_entry = directory_table
+            .id_entries()
             .next()
             .ok_or_else(|| Error::other("No manifest entry found"))?;
 
@@ -137,7 +165,7 @@ impl PE {
             .ok_or_else(|| Error::other("No manifest directory table found"))?;
 
         let version_directory = version_directory_table
-            .entries()
+            .id_entries()
             .next()
             .ok_or_else(|| Error::other("No manifest directory found"))?;
 
@@ -177,11 +205,10 @@ impl PE {
 
         let mut resource_directory = ResourceDirectory::new(section_reader)?;
 
-        let _manifest = resource_directory.find_manifest()?;
+        let manifest_directory_table = resource_directory.navigate_to_manifest()?;
 
-        let manifest_entry = resource_directory
-            .current_directory_table()
-            .entries()
+        let manifest_entry = manifest_directory_table
+            .id_entries()
             .next()
             .ok_or_else(|| Error::other("No manifest entry found"))?;
 
@@ -191,7 +218,7 @@ impl PE {
             .ok_or_else(|| Error::other("No manifest directory table found"))?;
 
         let manifest_directory = manifest_directory_table
-            .entries()
+            .id_entries()
             .next()
             .ok_or_else(|| Error::other("No manifest directory found"))?;
 

--- a/src/analysis/installers/pe/optional_header/data_directory.rs
+++ b/src/analysis/installers/pe/optional_header/data_directory.rs
@@ -1,9 +1,12 @@
-use std::{fmt, io};
+use std::{
+    fmt, io,
+    io::{Read, Seek},
+};
 
 use itertools::Itertools;
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, LittleEndian, U32};
 
-use super::super::SectionTable;
+use super::super::{SectionReader, SectionTable};
 
 /// Represents a PE data directory.
 ///
@@ -46,6 +49,16 @@ impl DataDirectory {
     #[inline]
     pub fn file_offset(self, section_table: &SectionTable) -> io::Result<u32> {
         section_table.to_file_offset(self.virtual_address())
+    }
+
+    pub fn section_reader<R: Read + Seek>(
+        self,
+        mut reader: R,
+        section_table: &SectionTable,
+    ) -> io::Result<SectionReader<R>> {
+        let mut directory_offset = self.file_offset(section_table)?;
+
+        SectionReader::new(reader, directory_offset.into(), self.size().into())
     }
 }
 

--- a/src/analysis/installers/pe/resource/directory.rs
+++ b/src/analysis/installers/pe/resource/directory.rs
@@ -3,7 +3,10 @@ use std::{
     io::{Read, Seek},
 };
 
-use super::{ImageResourceDirectoryEntry, ResourceDirectoryTable, ResourceType, SectionReader};
+use super::{
+    ImageResourceDirectoryEntry, NamedImageResourceDirectoryEntry, ResourceDirectoryTable,
+    ResourceType, SectionReader,
+};
 
 pub struct ResourceDirectory<R: Read + Seek> {
     reader: SectionReader<R>,
@@ -27,37 +30,58 @@ impl<R: Read + Seek> ResourceDirectory<R> {
         &self.current_directory_table
     }
 
-    pub fn find_rc_data(&mut self) -> io::Result<&ResourceDirectoryTable> {
-        self.find_directory_table_by_id(ResourceType::RCData.id())
+    pub fn navigate_to_rc_data(&mut self) -> io::Result<&ResourceDirectoryTable> {
+        self.navigate_to_directory_table(ResourceType::RCData)
     }
 
-    pub fn find_manifest(&mut self) -> io::Result<&ResourceDirectoryTable> {
-        self.find_directory_table_by_id(ResourceType::Manifest.id())
+    pub fn navigate_to_manifest(&mut self) -> io::Result<&ResourceDirectoryTable> {
+        self.navigate_to_directory_table(ResourceType::Manifest)
     }
 
-    pub fn find_version_info(&mut self) -> io::Result<&ResourceDirectoryTable> {
-        self.find_directory_table_by_id(ResourceType::Version.id())
+    pub fn navigate_to_version_info(&mut self) -> io::Result<&ResourceDirectoryTable> {
+        self.navigate_to_directory_table(ResourceType::Version)
     }
 
-    pub fn find_directory_table_by_id(&mut self, id: u32) -> io::Result<&ResourceDirectoryTable> {
-        let directory_entry = *self
-            .current_directory_table
-            .find_id_entry(id)
-            .ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("{id} not found in current directory table"),
-                )
-            })?;
+    pub fn navigate_to_directory_table(
+        &mut self,
+        resource_type: ResourceType,
+    ) -> io::Result<&ResourceDirectoryTable> {
+        self.navigate_to_directory_table_by_id(resource_type.id())
+    }
+
+    pub fn navigate_to_directory_table_by_id(
+        &mut self,
+        id: u32,
+    ) -> io::Result<&ResourceDirectoryTable> {
+        let mut directory_entry =
+            self.current_directory_table
+                .find_id_entry(id)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("{id} not found in current directory table"),
+                    )
+                })?;
 
         self.current_directory_table = directory_entry.data(self)?.table().unwrap();
         Ok(&self.current_directory_table)
     }
 
-    pub fn find_name_entry(&mut self, name: &str) -> Option<ImageResourceDirectoryEntry> {
-        self.current_directory_table
-            .clone()
-            .find_name_entry(self.reader_mut(), name)
-            .copied()
+    pub fn navigate_to_directory_table_by_name(
+        &mut self,
+        name: &str,
+    ) -> io::Result<&ResourceDirectoryTable> {
+        let mut directory_entry = self
+            .current_directory_table
+            .find_name_entry(name)
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("{name} not found in current directory table"),
+                )
+            })?;
+
+        self.current_directory_table = directory_entry.entry().data(self)?.table().unwrap();
+        Ok(&self.current_directory_table)
     }
 }

--- a/src/analysis/installers/pe/resource/directory_table.rs
+++ b/src/analysis/installers/pe/resource/directory_table.rs
@@ -1,0 +1,95 @@
+use std::{
+    io,
+    io::{Read, Seek},
+};
+
+use zerocopy::{FromBytes, FromZeros, IntoBytes};
+
+use super::{
+    IdImageResourceDirectoryEntry, IdOrNamedImageResourceDirectoryEntry, ImageResourceDirectory,
+    ImageResourceDirectoryEntry, NamedImageResourceDirectoryEntry, SectionReader,
+};
+
+#[derive(Clone, Debug)]
+pub struct ResourceDirectoryTable {
+    header: ImageResourceDirectory,
+    name_entries: Vec<NamedImageResourceDirectoryEntry>,
+    id_entries: Vec<IdImageResourceDirectoryEntry>,
+}
+
+impl ResourceDirectoryTable {
+    pub fn read_from<R>(src: &mut SectionReader<R>) -> io::Result<Self>
+    where
+        R: Read + Seek,
+    {
+        let header = ImageResourceDirectory::read_from_io(&mut *src)?;
+
+        let mut name_entries = vec![
+            ImageResourceDirectoryEntry::new_zeroed();
+            header.number_of_named_entries().into()
+        ];
+
+        for name_entry in &mut name_entries {
+            src.read_exact(name_entry.as_mut_bytes())?;
+        }
+
+        let mut id_entries =
+            vec![IdImageResourceDirectoryEntry::new_zeroed(); header.number_of_id_entries().into()];
+
+        for id_entry in &mut id_entries {
+            src.read_exact(id_entry.as_mut_bytes())?;
+        }
+
+        Ok(Self {
+            header,
+            name_entries: name_entries
+                .into_iter()
+                .flat_map(|entry| {
+                    entry
+                        .name()
+                        .to_string_lossy(src)
+                        .map(|name| NamedImageResourceDirectoryEntry::new(name, entry))
+                })
+                .collect(),
+            id_entries,
+        })
+    }
+
+    pub fn find_id_entry(&self, id: u32) -> Option<IdImageResourceDirectoryEntry> {
+        self.id_entries().find(|entry| entry.id() == id)
+    }
+
+    pub fn find_name_entry(&self, name: &str) -> Option<&NamedImageResourceDirectoryEntry> {
+        self.name_entries().find(|entry| entry.name() == name)
+    }
+
+    #[inline]
+    pub const fn number_of_name_entries(&self) -> u16 {
+        self.header.number_of_named_entries()
+    }
+
+    #[inline]
+    pub const fn number_of_id_entries(&self) -> u16 {
+        self.header.number_of_id_entries()
+    }
+
+    #[inline]
+    pub fn name_entries(&self) -> impl Iterator<Item = &NamedImageResourceDirectoryEntry> {
+        self.name_entries.iter()
+    }
+
+    #[inline]
+    pub fn id_entries(&self) -> impl Iterator<Item = IdImageResourceDirectoryEntry> {
+        self.id_entries.iter().copied()
+    }
+
+    pub fn entries(&self) -> impl Iterator<Item = IdOrNamedImageResourceDirectoryEntry> {
+        self.name_entries()
+            .cloned()
+            .map(IdOrNamedImageResourceDirectoryEntry::Named)
+            .chain(
+                self.id_entries()
+                    .map(IdOrNamedImageResourceDirectoryEntry::Id),
+            )
+    }
+}

--- a/src/analysis/installers/pe/resource/image/data_entry.rs
+++ b/src/analysis/installers/pe/resource/image/data_entry.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use zerocopy::{FromBytes, Immutable, KnownLayout, LittleEndian, U32};
 
 // Each resource data entry describes a leaf node in the resource directory tree. It contains an
@@ -6,7 +8,7 @@ use zerocopy::{FromBytes, Immutable, KnownLayout, LittleEndian, U32};
 // decoding code point values within the resource data. Typically, for new applications the code
 // page would be the Unicode code page.
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, FromBytes, Immutable, KnownLayout)]
+#[derive(Copy, Clone, Eq, PartialEq, FromBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct ImageResourceDataEntry {
     /// RVA of the data.
@@ -30,5 +32,21 @@ impl ImageResourceDataEntry {
     #[inline]
     pub const fn codepage(&self) -> u32 {
         self.codepage.get()
+    }
+
+    #[inline]
+    const fn reserved(&self) -> u32 {
+        self.reserved.get()
+    }
+}
+
+impl fmt::Debug for ImageResourceDataEntry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IMAGE_RESOURCE_DATA_ENTRY")
+            .field("OffsetToData", &self.offset_to_data())
+            .field("Size", &self.size())
+            .field("Codepage", &self.codepage())
+            .field("Reserved", &self.reserved())
+            .finish()
     }
 }

--- a/src/analysis/installers/pe/resource/image/directory_entry.rs
+++ b/src/analysis/installers/pe/resource/image/directory_entry.rs
@@ -1,6 +1,6 @@
 use std::{
-    io,
-    io::{Read, Seek},
+    fmt, io,
+    io::{Read, Seek, SeekFrom},
 };
 
 use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, LittleEndian, U32};
@@ -16,7 +16,7 @@ use crate::{
 
 pub const IMAGE_RESOURCE_NAME_IS_STRING: u32 = 0x8000_0000;
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Copy, Clone, Eq, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct ImageResourceDirectoryEntry {
     name_or_id: U32<LittleEndian>,
@@ -24,8 +24,9 @@ pub struct ImageResourceDirectoryEntry {
 }
 
 impl ImageResourceDirectoryEntry {
-    const IS_DIRECTORY_MASK: u32 = 1 << 31;
+    pub const IS_DIRECTORY_MASK: u32 = 1 << 31;
 
+    /// Returns `true` if this directory entry has a name.
     pub const fn has_name(self) -> bool {
         self.name_or_id() & IMAGE_RESOURCE_NAME_IS_STRING != 0
     }
@@ -43,6 +44,7 @@ impl ImageResourceDirectoryEntry {
         self.name_or_id.get()
     }
 
+    /// Returns the offset to the data or directory.
     #[inline]
     const fn offset_to_data_or_directory(self) -> u32 {
         self.offset_to_data_or_directory.get()
@@ -67,7 +69,7 @@ impl ImageResourceDirectoryEntry {
         R: Read + Seek,
     {
         let section_reader = section.reader_mut();
-        section_reader.seek(io::SeekFrom::Start(self.data_offset().into()))?;
+        section_reader.seek(SeekFrom::Start(self.data_offset().into()))?;
         if self.is_table() {
             ResourceDirectoryTable::read_from(section_reader).map(ResourceDirectoryEntryData::Table)
         } else {
@@ -79,5 +81,17 @@ impl ImageResourceDirectoryEntry {
 
     pub const fn file_offset(self, resource_offset: u32) -> u32 {
         self.data_offset() + resource_offset
+    }
+}
+
+impl fmt::Debug for ImageResourceDirectoryEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("ImageResourceDirectoryEntry")
+            .field("NameOrID", &self.name_or_id())
+            .field(
+                "OffsetToDataOrDirectory",
+                &self.offset_to_data_or_directory(),
+            )
+            .finish()
     }
 }

--- a/src/analysis/installers/pe/resource/image/directory_header.rs
+++ b/src/analysis/installers/pe/resource/image/directory_header.rs
@@ -1,44 +1,69 @@
+use std::fmt;
+
 use zerocopy::{FromBytes, Immutable, KnownLayout, LittleEndian, U16, U32};
 
-#[derive(Copy, Clone, Debug, Eq, PartialEq, FromBytes, Immutable, KnownLayout)]
+#[derive(Copy, Clone, Eq, PartialEq, FromBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct ImageResourceDirectory {
     characteristics: U32<LittleEndian>,
     time_date_stamp: U32<LittleEndian>,
     major_version: U16<LittleEndian>,
     minor_version: U16<LittleEndian>,
-    number_of_name_entries: U16<LittleEndian>,
+    number_of_named_entries: U16<LittleEndian>,
     number_of_id_entries: U16<LittleEndian>,
 }
 
 impl ImageResourceDirectory {
+    /// Returns the resource flags.
+    ///
+    /// This field is reserved for future use. It is currently set to zero.
     #[inline]
     pub const fn characteristics(&self) -> u32 {
         self.characteristics.get()
     }
 
+    /// Returns the time that the resource data was created by the resource compiler.
     #[inline]
     pub const fn time_date_stamp(&self) -> u32 {
         self.time_date_stamp.get()
     }
 
+    /// Returns the major version number, set by the user.
     #[inline]
     pub const fn major_version(&self) -> u16 {
         self.major_version.get()
     }
 
+    /// Returns the minor version number, set by the user.
     #[inline]
     pub const fn minor_version(&self) -> u16 {
         self.major_version.get()
     }
 
+    /// Returns the number of directory entries immediately following the table that use strings to
+    /// identify Type, Name, or Language entries (depending on the level of the table).
     #[inline]
-    pub const fn number_of_name_entries(&self) -> u16 {
-        self.number_of_name_entries.get()
+    pub const fn number_of_named_entries(&self) -> u16 {
+        self.number_of_named_entries.get()
     }
 
+    /// Returns the number of directory entries immediately following the Name entries that use
+    /// numeric IDs for Type, Name, or Language entries.
     #[inline]
     pub const fn number_of_id_entries(&self) -> u16 {
         self.number_of_id_entries.get()
+    }
+}
+
+impl fmt::Debug for ImageResourceDirectory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("IMAGE_RESOURCE_DIRECTORY")
+            .field("Characteristics", &self.characteristics())
+            .field("TimeDateStamp", &self.time_date_stamp())
+            .field("MajorVersion", &self.major_version())
+            .field("MinorVersion", &self.minor_version())
+            .field("NumberOfNamedEntries", &self.number_of_named_entries())
+            .field("NumberOfIdEntries", &self.number_of_id_entries())
+            .finish()
     }
 }

--- a/src/analysis/installers/pe/resource/image/id_directory_entry.rs
+++ b/src/analysis/installers/pe/resource/image/id_directory_entry.rs
@@ -1,0 +1,72 @@
+use std::{
+    fmt, io,
+    io::{Read, Seek},
+};
+
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, LittleEndian, U32};
+
+use crate::analysis::installers::pe::resource::{
+    ImageResourceDataEntry, ImageResourceDirectoryEntry, ResourceDirectory, ResourceDirectoryTable,
+    ResourceType, directory_entry_data::ResourceDirectoryEntryData,
+};
+
+#[derive(Copy, Clone, Eq, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(transparent)]
+pub struct IdImageResourceDirectoryEntry(ImageResourceDirectoryEntry);
+
+impl IdImageResourceDirectoryEntry {
+    #[inline]
+    pub const fn new(entry: ImageResourceDirectoryEntry) -> Self {
+        Self(entry)
+    }
+
+    /// Returns a 32-bit integer that identifies the Type, Name, or Language ID entry.
+    #[inline]
+    pub const fn id(self) -> u32 {
+        self.entry().name_or_id()
+    }
+
+    #[inline]
+    pub const fn entry(self) -> ImageResourceDirectoryEntry {
+        self.0
+    }
+
+    /// Returns the data associated to this directory entry.
+    pub fn data<R>(
+        self,
+        section: &mut ResourceDirectory<R>,
+    ) -> io::Result<ResourceDirectoryEntryData>
+    where
+        R: Read + Seek,
+    {
+        self.entry().data(section)
+    }
+
+    /// Returns the section offset of the associated table or data.
+    #[inline]
+    pub const fn data_offset(self) -> u32 {
+        self.entry().data_offset()
+    }
+
+    #[inline]
+    pub const fn file_offset(self, resource_offset: u32) -> u32 {
+        self.entry().file_offset(resource_offset)
+    }
+}
+
+impl fmt::Debug for IdImageResourceDirectoryEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut buffer = itoa::Buffer::new();
+
+        f.debug_struct("IdImageResourceDirectoryEntry")
+            .field(
+                "ID",
+                &ResourceType::try_from(self.id())
+                    .map(ResourceType::as_str)
+                    .unwrap_or_else(|_| buffer.format(self.id())),
+            )
+            .field("Table", &self.entry().is_table())
+            .field("Offset", &self.data_offset())
+            .finish()
+    }
+}

--- a/src/analysis/installers/pe/resource/image/id_or_name.rs
+++ b/src/analysis/installers/pe/resource/image/id_or_name.rs
@@ -1,0 +1,11 @@
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IdOrName {
+    Id(u32),
+    Name(String),
+}
+
+impl Default for IdOrName {
+    fn default() -> Self {
+        Self::Id(0)
+    }
+}

--- a/src/analysis/installers/pe/resource/image/id_or_named_directory_entry.rs
+++ b/src/analysis/installers/pe/resource/image/id_or_named_directory_entry.rs
@@ -1,0 +1,52 @@
+use std::{
+    io,
+    io::{Read, Seek},
+};
+
+use super::{
+    super::{ResourceDirectory, directory_entry_data::ResourceDirectoryEntryData},
+    IdImageResourceDirectoryEntry, IdOrName, NamedImageResourceDirectoryEntry,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum IdOrNamedImageResourceDirectoryEntry {
+    Id(IdImageResourceDirectoryEntry),
+    Named(NamedImageResourceDirectoryEntry),
+}
+
+impl IdOrNamedImageResourceDirectoryEntry {
+    pub fn into_id(self) -> Option<IdImageResourceDirectoryEntry> {
+        match self {
+            Self::Id(id) => Some(id),
+            Self::Named(named) => None,
+        }
+    }
+
+    pub const fn id(&self) -> u32 {
+        match self {
+            Self::Id(id) => id.id(),
+            Self::Named(named) => named.raw_id(),
+        }
+    }
+
+    pub fn id_or_name(&self) -> IdOrName {
+        match self {
+            Self::Id(id) => IdOrName::Id(id.id()),
+            Self::Named(named) => IdOrName::Name(named.name().to_owned()),
+        }
+    }
+
+    /// Returns the data associated to this directory entry.
+    pub fn data<R>(
+        self,
+        section: &mut ResourceDirectory<R>,
+    ) -> io::Result<ResourceDirectoryEntryData>
+    where
+        R: Read + Seek,
+    {
+        match self {
+            Self::Id(id) => id.data(section),
+            Self::Named(named) => named.data(section),
+        }
+    }
+}

--- a/src/analysis/installers/pe/resource/image/mod.rs
+++ b/src/analysis/installers/pe/resource/image/mod.rs
@@ -1,7 +1,15 @@
 mod data_entry;
 mod directory_entry;
 mod directory_header;
+mod id_directory_entry;
+mod id_or_name;
+mod id_or_named_directory_entry;
+mod named_directory_entry;
 
 pub use data_entry::ImageResourceDataEntry;
 pub use directory_entry::ImageResourceDirectoryEntry;
 pub use directory_header::ImageResourceDirectory;
+pub use id_directory_entry::IdImageResourceDirectoryEntry;
+pub use id_or_name::IdOrName;
+pub use id_or_named_directory_entry::IdOrNamedImageResourceDirectoryEntry;
+pub use named_directory_entry::NamedImageResourceDirectoryEntry;

--- a/src/analysis/installers/pe/resource/image/named_directory_entry.rs
+++ b/src/analysis/installers/pe/resource/image/named_directory_entry.rs
@@ -1,0 +1,73 @@
+use std::{
+    fmt, io,
+    io::{Read, Seek},
+};
+
+use super::{
+    super::{ResourceDirectory, ResourceDirectoryEntryData},
+    ImageResourceDirectoryEntry,
+};
+
+/// An [`ImageResourceDirectoryEntry`] with a resolved name.
+#[derive(Clone, Eq, PartialEq)]
+pub struct NamedImageResourceDirectoryEntry {
+    name: String,
+    entry: ImageResourceDirectoryEntry,
+}
+
+impl NamedImageResourceDirectoryEntry {
+    /// Returns a new [`NamedImageResourceDirectoryEntry`] from a [`String`] and an
+    /// [`ImageResourceDirectoryEntry`].
+    #[inline]
+    pub const fn new(name: String, entry: ImageResourceDirectoryEntry) -> Self {
+        Self { name, entry }
+    }
+
+    /// Returns the name of the [`NamedImageResourceDirectoryEntry`].
+    pub const fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    #[inline]
+    pub const fn entry(&self) -> ImageResourceDirectoryEntry {
+        self.entry
+    }
+
+    /// Returns the raw ID of the directory entry.
+    #[inline]
+    pub const fn raw_id(&self) -> u32 {
+        self.entry().name_or_id()
+    }
+
+    /// Returns true if this directory entry is a table.
+    #[inline]
+    pub const fn is_table(&self) -> bool {
+        self.entry().is_table()
+    }
+
+    #[inline]
+    pub const fn data_offset(&self) -> u32 {
+        self.entry().data_offset()
+    }
+
+    /// Returns the data associated to this directory entry.
+    pub fn data<R>(
+        &self,
+        section: &mut ResourceDirectory<R>,
+    ) -> io::Result<ResourceDirectoryEntryData>
+    where
+        R: Read + Seek,
+    {
+        self.entry().data(section)
+    }
+}
+
+impl fmt::Debug for NamedImageResourceDirectoryEntry {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("NamedImageResourceDirectoryEntry")
+            .field("Name", &self.name())
+            .field("Table", &self.is_table())
+            .field("Offset", &self.data_offset())
+            .finish()
+    }
+}

--- a/src/analysis/installers/pe/resource/iterator.rs
+++ b/src/analysis/installers/pe/resource/iterator.rs
@@ -1,0 +1,85 @@
+use std::{
+    collections::VecDeque,
+    io::{Read, Seek},
+};
+
+use super::{
+    IdImageResourceDirectoryEntry, IdOrName, IdOrNamedImageResourceDirectoryEntry, Resource,
+    ResourceDirectory, ResourceDirectoryEntryData,
+};
+
+pub struct ResourceIter<R: Read + Seek> {
+    dir: ResourceDirectory<R>,
+
+    type_entries: VecDeque<IdOrNamedImageResourceDirectoryEntry>,
+    name_entries: VecDeque<IdImageResourceDirectoryEntry>,
+    lang_entries: VecDeque<IdImageResourceDirectoryEntry>,
+
+    current_type: IdOrName,
+    current_name_id: u32,
+}
+
+impl<R: Read + Seek> ResourceIter<R> {
+    pub fn new(mut dir: ResourceDirectory<R>) -> Self {
+        let root = dir.current_directory_table();
+
+        Self {
+            type_entries: root.entries().collect(),
+            dir,
+
+            name_entries: VecDeque::new(),
+
+            lang_entries: VecDeque::new(),
+
+            current_type: IdOrName::default(),
+            current_name_id: 0,
+        }
+    }
+}
+
+impl<R: Read + Seek> Iterator for ResourceIter<R> {
+    type Item = Resource;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            // Language level
+            if let Some(lang_entry) = self.lang_entries.pop_front() {
+                return Some(Resource {
+                    r#type: self.current_type.clone(),
+                    name_id: self.current_name_id,
+                    language_id: lang_entry.id(),
+                    entry: lang_entry.data(&mut self.dir).ok()?.data()?,
+                });
+            }
+
+            // Name level
+            if let Some(name_entry) = self.name_entries.pop_front() {
+                self.lang_entries = name_entry
+                    .data(&mut self.dir)
+                    .ok()
+                    .and_then(ResourceDirectoryEntryData::table)?
+                    .id_entries()
+                    .collect();
+                self.current_name_id = name_entry.id();
+
+                continue;
+            }
+
+            // Type level
+            if let Some(type_entry) = self.type_entries.pop_front() {
+                self.current_type = type_entry.id_or_name();
+
+                self.name_entries = type_entry
+                    .data(&mut self.dir)
+                    .ok()
+                    .and_then(ResourceDirectoryEntryData::table)?
+                    .id_entries()
+                    .collect();
+
+                continue;
+            }
+
+            return None;
+        }
+    }
+}

--- a/src/analysis/installers/pe/resource/mod.rs
+++ b/src/analysis/installers/pe/resource/mod.rs
@@ -1,84 +1,76 @@
 mod directory;
 mod directory_entry_data;
+mod directory_table;
 mod image;
+mod iterator;
 mod name;
 mod resource_types;
 mod section_reader;
 
-use std::io;
+use std::{
+    fmt,
+    io::{Read, Seek},
+};
 
 pub use directory::ResourceDirectory;
-pub use image::{ImageResourceDataEntry, ImageResourceDirectory, ImageResourceDirectoryEntry};
+pub use directory_entry_data::ResourceDirectoryEntryData;
+pub use directory_table::ResourceDirectoryTable;
+pub use image::{
+    IdImageResourceDirectoryEntry, IdOrName, IdOrNamedImageResourceDirectoryEntry,
+    ImageResourceDataEntry, ImageResourceDirectory, ImageResourceDirectoryEntry,
+    NamedImageResourceDirectoryEntry,
+};
+pub use iterator::ResourceIter;
 pub use resource_types::ResourceType;
 pub use section_reader::SectionReader;
 use zerocopy::{FromBytes, FromZeros, IntoBytes};
 
-#[derive(Clone, Debug)]
-pub struct ResourceDirectoryTable {
-    pub header: ImageResourceDirectory,
-    name_entries: Vec<ImageResourceDirectoryEntry>,
-    id_entries: Vec<ImageResourceDirectoryEntry>,
+pub struct Resource {
+    r#type: IdOrName,
+    name_id: u32,
+    language_id: u32,
+    entry: ImageResourceDataEntry,
 }
 
-impl ResourceDirectoryTable {
-    pub fn read_from<R>(mut src: R) -> io::Result<Self>
-    where
-        R: io::Read,
-    {
-        let header = ImageResourceDirectory::read_from_io(&mut src)?;
-
-        let mut name_entries =
-            vec![ImageResourceDirectoryEntry::new_zeroed(); header.number_of_name_entries().into()];
-
-        for name_entry in &mut name_entries {
-            src.read_exact(name_entry.as_mut_bytes())?;
-        }
-
-        let mut id_entries =
-            vec![ImageResourceDirectoryEntry::new_zeroed(); header.number_of_id_entries().into()];
-
-        for id_entry in &mut id_entries {
-            src.read_exact(id_entry.as_mut_bytes())?;
-        }
-
-        Ok(Self {
-            header,
-            name_entries,
-            id_entries,
-        })
+impl Resource {
+    pub const fn id_or_name(&self) -> &IdOrName {
+        &self.r#type
     }
-
-    pub fn find_id_entry(&self, id: u32) -> Option<&ImageResourceDirectoryEntry> {
-        self.id_entries().find(|entry| entry.name_or_id() == id)
-    }
-
-    pub fn find_name_entry<R>(
-        &self,
-        section_reader: &mut SectionReader<R>,
-        name: &str,
-    ) -> Option<&ImageResourceDirectoryEntry>
-    where
-        R: io::Read + io::Seek,
-    {
-        self.name_entries().find(|entry| {
-            entry
-                .name()
-                .to_string_lossy(section_reader)
-                .is_ok_and(|entry_name| entry_name == name)
-        })
+    pub const fn name(&self) -> Option<&str> {
+        match self.r#type {
+            IdOrName::Name(ref name) => Some(name.as_str()),
+            IdOrName::Id(_) => None,
+        }
     }
 
     #[inline]
-    pub fn id_entries(&self) -> impl Iterator<Item = &ImageResourceDirectoryEntry> {
-        self.id_entries.iter()
+    pub const fn offset_to_data(&self) -> u32 {
+        self.entry.offset_to_data()
     }
 
     #[inline]
-    pub fn name_entries(&self) -> impl Iterator<Item = &ImageResourceDirectoryEntry> {
-        self.name_entries.iter()
+    pub const fn size(&self) -> u32 {
+        self.entry.size()
     }
+}
 
-    pub fn entries(&self) -> impl Iterator<Item = &ImageResourceDirectoryEntry> {
-        self.name_entries().chain(self.id_entries())
+impl fmt::Debug for Resource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut buffer = itoa::Buffer::new();
+
+        f.debug_struct("Resource")
+            .field(
+                "TypeID",
+                &match self.r#type {
+                    IdOrName::Id(id) => ResourceType::try_from(id)
+                        .map(ResourceType::as_str)
+                        .unwrap_or_else(|_| buffer.format(id)),
+                    IdOrName::Name(ref name) => name,
+                },
+            )
+            .field("NameID", &self.name_id)
+            .field("LanguageID", &self.language_id)
+            .field("Entry", &self.entry)
+            .finish()
     }
 }

--- a/src/analysis/installers/pe/resource/name.rs
+++ b/src/analysis/installers/pe/resource/name.rs
@@ -21,8 +21,8 @@ impl ResourceName {
         Self { offset }
     }
 
-    /// Converts to a `String`, replacing
-    /// invalid data with [the replacement character (`U+FFFD`)][U+FFFD].
+    /// Converts to a `String`, replacing invalid data with
+    /// [the replacement character (`U+FFFD`)][U+FFFD].
     ///
     /// [U+FFFD]: core::char::REPLACEMENT_CHARACTER
     pub fn to_string_lossy<R: Read + Seek>(
@@ -35,7 +35,7 @@ impl ResourceName {
         let mut buf = vec![0; usize::from(length) * size_of::<u16>()];
         reader.read_exact(buf.as_mut_bytes())?;
 
-        /// Could be replaced with [String::from_utf16le_lossy]
+        /// Could be replaced with [`String::from_utf16le_lossy`]
         Ok(UTF_16LE.decode_without_bom_handling(&buf).0.into_owned())
     }
 }

--- a/src/analysis/installers/pe/resource/resource_types.rs
+++ b/src/analysis/installers/pe/resource/resource_types.rs
@@ -78,6 +78,34 @@ impl ResourceType {
     pub const fn id(self) -> u32 {
         self as u32
     }
+
+    /// Returns the resource type as a static string.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cursor => "RT_CURSOR",
+            Self::Bitmap => "RT_BITMAP",
+            Self::Icon => "RT_ICON",
+            Self::Menu => "RT_MENU",
+            Self::Dialog => "RT_DIALOG",
+            Self::String => "RT_STRING",
+            Self::FontDirectory => "RT_FONTDIR",
+            Self::Font => "RT_FONT",
+            Self::Accelerator => "RT_ACCELERATOR",
+            Self::RCData => "RT_RCDATA",
+            Self::MessageTable => "RT_MESSAGETABLE",
+            Self::GroupCursor => "RT_GROUP_CURSOR",
+            Self::GroupIcon => "RT_GROUP_ICON",
+            Self::Version => "RT_VERSION",
+            Self::DialogInclude => "RT_DLGINCLUDE",
+            Self::PlugPlay => "RT_PLUGPLAY",
+            Self::Vxd => "RT_VXD",
+            Self::AnimatedCursor => "RT_ANICURSOR",
+            Self::AnimatedIcon => "RT_ANIICON",
+            Self::Html => "RT_HTML",
+            Self::Manifest => "RT_MANIFEST",
+        }
+    }
 }
 
 impl fmt::Debug for ResourceType {
@@ -88,29 +116,7 @@ impl fmt::Debug for ResourceType {
 
 impl fmt::Display for ResourceType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Cursor => f.write_str("RT_CURSOR"),
-            Self::Bitmap => f.write_str("RT_BITMAP"),
-            Self::Icon => f.write_str("RT_ICON"),
-            Self::Menu => f.write_str("RT_MENU"),
-            Self::Dialog => f.write_str("RT_DIALOG"),
-            Self::String => f.write_str("RT_STRING"),
-            Self::FontDirectory => f.write_str("RT_FONTDIR"),
-            Self::Font => f.write_str("RT_FONT"),
-            Self::Accelerator => f.write_str("RT_ACCELERATOR"),
-            Self::RCData => f.write_str("RT_RCDATA"),
-            Self::MessageTable => f.write_str("RT_MESSAGETABLE"),
-            Self::GroupCursor => f.write_str("RT_GROUP_CURSOR"),
-            Self::GroupIcon => f.write_str("RT_GROUP_ICON"),
-            Self::Version => f.write_str("RT_VERSION"),
-            Self::DialogInclude => f.write_str("RT_DLGINCLUDE"),
-            Self::PlugPlay => f.write_str("RT_PLUGPLAY"),
-            Self::Vxd => f.write_str("RT_VXD"),
-            Self::AnimatedCursor => f.write_str("RT_ANICURSOR"),
-            Self::AnimatedIcon => f.write_str("RT_ANIICON"),
-            Self::Html => f.write_str("RT_HTML"),
-            Self::Manifest => f.write_str("RT_MANIFEST"),
-        }
+        self.as_str().fmt(f)
     }
 }
 
@@ -118,5 +124,36 @@ impl From<ResourceType> for u32 {
     #[inline]
     fn from(resource_type: ResourceType) -> Self {
         resource_type.id()
+    }
+}
+
+impl TryFrom<u32> for ResourceType {
+    type Error = &'static str;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Cursor),
+            2 => Ok(Self::Bitmap),
+            3 => Ok(Self::Icon),
+            4 => Ok(Self::Menu),
+            5 => Ok(Self::Dialog),
+            6 => Ok(Self::String),
+            7 => Ok(Self::FontDirectory),
+            8 => Ok(Self::Font),
+            9 => Ok(Self::Accelerator),
+            10 => Ok(Self::RCData),
+            11 => Ok(Self::MessageTable),
+            12 => Ok(Self::GroupCursor),
+            14 => Ok(Self::GroupIcon),
+            16 => Ok(Self::Version),
+            17 => Ok(Self::DialogInclude),
+            19 => Ok(Self::PlugPlay),
+            20 => Ok(Self::Vxd),
+            21 => Ok(Self::AnimatedCursor),
+            22 => Ok(Self::AnimatedIcon),
+            23 => Ok(Self::Html),
+            24 => Ok(Self::Manifest),
+            _ => Err("Unknown resource type"),
+        }
     }
 }

--- a/src/analysis/installers/pe/resource/section_reader.rs
+++ b/src/analysis/installers/pe/resource/section_reader.rs
@@ -3,6 +3,9 @@ use std::{
     io::{self, Read, Seek, SeekFrom},
 };
 
+/// A [`Reader`] that restricts the reads and seeks given section of the underlying reader.
+///
+/// [`Reader`]: Read
 pub struct SectionReader<R> {
     inner: R,
     start: u64,
@@ -11,7 +14,37 @@ pub struct SectionReader<R> {
 }
 
 impl<R: Read + Seek> SectionReader<R> {
+    /// Creates a new [`SectionReader`] from a [`Reader`], a section start, and a section length.
+    ///
+    /// Seeks on the [`SectionReader`] will be relative to the section.
+    ///
+    /// [`Reader`]: Read
     pub fn new(mut inner: R, start: u64, length: u64) -> io::Result<Self> {
+        // Seek to the start of the section
+        inner.seek(SeekFrom::Start(start))?;
+
+        Ok(Self {
+            inner,
+            start,
+            length,
+            position: 0,
+        })
+    }
+
+    /// Creates a new [`SectionReader`] from a [`Reader`] and a section start.
+    ///
+    /// The length of the section will be the bytes remaining after start, determined by
+    /// `SeekFrom::End(0)`.
+    ///
+    /// Seeks on the [`SectionReader`] will be relative to the section.
+    ///
+    /// [`Reader`]: Read
+    pub fn from_offset(mut inner: R, start: u64) -> io::Result<Self> {
+        let length = inner
+            .seek(SeekFrom::End(0))?
+            .checked_sub(start)
+            .ok_or_else(|| io::Error::other("SectionReader end is before start"))?;
+
         // Seek to the start of the section
         inner.seek(SeekFrom::Start(start))?;
 
@@ -51,12 +84,14 @@ impl<R: Read + Seek> SectionReader<R> {
 impl<R: Read + Seek> Read for SectionReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         let remaining = self.remaining();
+
         if remaining == 0 {
             return Ok(0); // EOF
         }
 
         // Limit read to remaining bytes in section
         let to_read = cmp::min(buf.len() as u64, remaining) as usize;
+
         let bytes_read = self.inner.read(&mut buf[..to_read])?;
 
         self.position += bytes_read as u64;

--- a/src/analysis/installers/pe/utils.rs
+++ b/src/analysis/installers/pe/utils.rs
@@ -1,0 +1,40 @@
+use std::{io, io::Read, mem::offset_of};
+
+use zerocopy::LE;
+
+use super::DosHeader;
+use crate::read::ReadBytesExt;
+
+/// Returns the machine value from a PE executable reader.
+///
+/// The reader's cursor is expected to be at the start of the executable.
+/// This function does not require the underlying reader to implement [`Seek`], instead seeking
+/// forward by reading data into the [void].
+///
+/// [`Seek`]: io::Seek
+/// [void]: io::Sink
+pub fn machine_from_exe_reader<R>(mut reader: R) -> io::Result<u16>
+where
+    R: Read,
+{
+    const PE_POINTER_OFFSET: u8 = offset_of!(DosHeader, pe_pointer) as u8;
+
+    let mut void = io::sink();
+
+    // Seek to COFF header offset inside exe
+    io::copy(
+        &mut reader.by_ref().take(PE_POINTER_OFFSET.into()),
+        &mut void,
+    )?;
+
+    let coff_offset = reader.read_u32::<LE>()?;
+
+    let Some(read_count) = coff_offset.checked_sub(PE_POINTER_OFFSET.into()) else {
+        return Err(io::Error::other("Invalid PE COFF offset"));
+    };
+
+    // Seek to machine value
+    io::copy(&mut reader.by_ref().take(u64::from(read_count)), &mut void)?;
+
+    reader.read_u16::<LE>()
+}

--- a/src/analysis/installers/squirrel/mod.rs
+++ b/src/analysis/installers/squirrel/mod.rs
@@ -1,0 +1,178 @@
+mod nupkg_reader;
+mod nuspec;
+
+use std::{
+    io::{self, Read, Seek, SeekFrom},
+    path::Path,
+};
+
+use camino::{Utf8Path, Utf8PathBuf};
+use nupkg_reader::NupkgReader;
+use nuspec::NuSpec;
+use quick_xml::de::from_str;
+use thiserror::Error;
+use tracing::debug;
+use winget_types::installer::{
+    AppsAndFeaturesEntry, Architecture, InstallationMetadata, Installer, InstallerSwitches,
+    InstallerType, Scope,
+};
+use zip::ZipArchive;
+
+use super::pe::utils::machine_from_exe_reader;
+use crate::{
+    analysis::{
+        Installers,
+        installers::pe::{PE, resource::SectionReader},
+    },
+    traits::FromMachine,
+};
+
+#[derive(Error, Debug)]
+pub enum SquirrelError {
+    #[error("File is not a Squirrel installer")]
+    NotSquirrelFile,
+    #[error("No nupkg found in Squirrel zip")]
+    NoNupkgFound,
+    #[error("No nuspec found in nupkg")]
+    NoNuspecFound,
+    #[error(transparent)]
+    NuspecDeserialization(#[from] quick_xml::DeError),
+    #[error(transparent)]
+    Zip(#[from] zip::result::ZipError),
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+pub struct Squirrel {
+    pub architecture: Architecture,
+    pub nuspec: NuSpec,
+    pub is_velopack: bool,
+}
+
+impl Squirrel {
+    pub fn new<R: Read + Seek>(mut reader: R, pe: &PE) -> Result<Self, SquirrelError> {
+        let mut is_velopack = false;
+
+        let mut nupkg = if let Ok(Ok(mut zip)) = pe
+            .find_resource_by_name(&mut reader, "DATA")
+            .map(ZipArchive::new)
+        {
+            // Squirrel
+            let nupkg_name = zip
+                .file_names()
+                .find(|name| {
+                    Path::new(name)
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("nupkg"))
+                })
+                .ok_or(SquirrelError::NoNupkgFound)?
+                .to_owned();
+            let mut nupkg_reader = zip.by_name(&nupkg_name)?;
+
+            // Copy the .nupkg file to a temporary file
+            let mut nupkg_file = tempfile::tempfile()?;
+            io::copy(&mut nupkg_reader, &mut nupkg_file)?;
+            nupkg_file.seek(SeekFrom::Start(0))?;
+
+            ZipArchive::new(NupkgReader::File(nupkg_file))
+                .map_err(|_| SquirrelError::NotSquirrelFile)?
+        } else {
+            // Velopack (Squirrel fork)
+            let header_offset = pe.overlay_offset().ok_or(SquirrelError::NotSquirrelFile)?;
+            let section_reader = SectionReader::from_offset(reader, header_offset)?;
+            is_velopack = true;
+
+            ZipArchive::new(NupkgReader::Section(section_reader))
+                .map_err(|_| SquirrelError::NotSquirrelFile)?
+        };
+
+        debug!(is_velopack);
+
+        let nuspec_filename = nupkg
+            .file_names()
+            .find(|name| name.ends_with(".nuspec"))
+            .ok_or(SquirrelError::NoNuspecFound)?
+            .to_owned();
+        let nuspec_data = io::read_to_string(nupkg.by_name(&nuspec_filename)?)?;
+        debug!(%nuspec_data);
+        let nuspec: NuSpec = from_str(&nuspec_data)?;
+
+        let entrypoint = nupkg
+            .file_names()
+            .map(Utf8Path::new)
+            .filter(|name| {
+                name.extension()
+                    .is_some_and(|ext| ext.eq_ignore_ascii_case("exe"))
+            })
+            .find(|name| {
+                name.file_stem().is_some_and(|stem| {
+                    nuspec
+                        .main_exe()
+                        .is_some_and(|main_exe| main_exe.eq_ignore_ascii_case(stem))
+                        || stem.eq_ignore_ascii_case(nuspec.id())
+                        || nuspec
+                            .title()
+                            .is_some_and(|title| title.eq_ignore_ascii_case(stem))
+                })
+            })
+            .map(Utf8Path::to_path_buf);
+
+        let architecture = entrypoint
+            .and_then(|entrypoint| {
+                let reader = nupkg.by_name(entrypoint.as_str()).ok()?;
+
+                let machine = machine_from_exe_reader(reader).ok()?;
+                Some(Architecture::from_machine(machine))
+            })
+            .unwrap_or_else(|| Architecture::from_machine(pe.machine()));
+
+        Ok(Self {
+            architecture,
+            nuspec,
+            is_velopack,
+        })
+    }
+}
+
+impl Installers for Squirrel {
+    fn installers(&self) -> Vec<Installer> {
+        let nuspec = &self.nuspec;
+
+        let switches = if self.is_velopack {
+            InstallerSwitches::builder()
+                .silent("--silent".parse().unwrap())
+                .silent_with_progress("--silent".parse().unwrap())
+                .install_location(r#"--installto "<INSTALLPATH>""#.parse().unwrap())
+                .log(r#"--log "<LOGPATH>""#.parse().unwrap())
+                .build()
+        } else {
+            InstallerSwitches::builder()
+                .silent("--silent".parse().unwrap())
+                .silent_with_progress("--silent".parse().unwrap())
+                .build()
+        };
+
+        vec![Installer {
+            architecture: self.architecture,
+            r#type: Some(InstallerType::Exe),
+            scope: Some(Scope::User),
+            product_code: Some(nuspec.id().to_owned()),
+            apps_and_features_entries: AppsAndFeaturesEntry::builder()
+                .display_name(nuspec.title().unwrap_or_else(|| nuspec.id()).to_owned())
+                .publisher(nuspec.authors().to_owned())
+                .display_version(nuspec.version().to_owned())
+                .product_code(nuspec.id().to_owned())
+                .build()
+                .into(),
+            switches,
+            installation_metadata: InstallationMetadata {
+                default_install_location: Some(Utf8PathBuf::from(format!(
+                    r"%LocalAppData%\{}",
+                    nuspec.id()
+                ))),
+                ..InstallationMetadata::default()
+            },
+            ..Installer::default()
+        }]
+    }
+}

--- a/src/analysis/installers/squirrel/nupkg_reader.rs
+++ b/src/analysis/installers/squirrel/nupkg_reader.rs
@@ -1,0 +1,29 @@
+use std::{
+    fs::File,
+    io::{Read, Result, Seek, SeekFrom},
+};
+
+use crate::analysis::installers::pe::resource::SectionReader;
+
+pub enum NupkgReader<R: Read + Seek> {
+    File(File),
+    Section(SectionReader<R>),
+}
+
+impl<R: Read + Seek> Read for NupkgReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match self {
+            Self::File(file) => file.read(buf),
+            Self::Section(reader) => reader.read(buf),
+        }
+    }
+}
+
+impl<R: Read + Seek> Seek for NupkgReader<R> {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64> {
+        match self {
+            Self::File(file) => file.seek(pos),
+            Self::Section(reader) => reader.seek(pos),
+        }
+    }
+}

--- a/src/analysis/installers/squirrel/nuspec.rs
+++ b/src/analysis/installers/squirrel/nuspec.rs
@@ -1,0 +1,122 @@
+#![expect(unused)]
+
+use serde::Deserialize;
+
+/// <https://learn.microsoft.com/nuget/reference/nuspec>
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+pub struct NuSpec {
+    pub metadata: Metadata,
+}
+
+impl NuSpec {
+    /// Returns the case-insensitive package identifier.
+    #[must_use]
+    #[inline]
+    pub const fn id(&self) -> &str {
+        self.metadata.id()
+    }
+
+    /// Returns the version of the package.
+    #[must_use]
+    #[inline]
+    pub const fn version(&self) -> &str {
+        self.metadata.version()
+    }
+
+    /// Returns a description of the package for UI display.
+    #[must_use]
+    #[inline]
+    pub const fn description(&self) -> &str {
+        self.metadata.description()
+    }
+
+    /// Returns a comma-separated list of package authors.
+    #[must_use]
+    #[inline]
+    pub const fn authors(&self) -> &str {
+        self.metadata.authors()
+    }
+
+    /// Returns a human-friendly title of the package which may be used in some UI displays.
+    #[must_use]
+    #[inline]
+    pub fn title(&self) -> Option<&str> {
+        self.metadata.title()
+    }
+
+    /// Returns the name of the main executable.
+    #[must_use]
+    #[inline]
+    pub fn main_exe(&self) -> Option<&str> {
+        self.metadata.main_exe()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Metadata {
+    /// The case-insensitive package identifier, which must be unique across nuget.org or whatever
+    /// gallery the package resides in. IDs may not contain spaces or characters that are not valid
+    /// for a URL, and generally follow .NET namespace rules. See
+    /// [Choosing a unique package identifier] for guidance.
+    ///
+    /// When uploading a package to nuget.org, the `id` field is limited to 128 characters.
+    ///
+    /// [Choosing a unique package identifier]: https://learn.microsoft.com/nuget/create-packages/creating-a-package#choose-a-unique-package-identifier-and-setting-the-version-number
+    id: String,
+    version: String,
+    description: String,
+    authors: String,
+    owners: Option<String>,
+
+    // Some forks don't require title
+    title: Option<String>,
+
+    // Velopack
+    main_exe: Option<String>,
+    // TODO pass releaseNotes to create/update commands
+}
+
+impl Metadata {
+    /// Returns the case-insensitive package identifier.
+    #[must_use]
+    #[inline]
+    pub const fn id(&self) -> &str {
+        self.id.as_str()
+    }
+
+    /// Returns the version of the package.
+    #[must_use]
+    #[inline]
+    pub const fn version(&self) -> &str {
+        self.version.as_str()
+    }
+
+    /// Returns a description of the package for UI display.
+    #[must_use]
+    #[inline]
+    pub const fn description(&self) -> &str {
+        self.description.as_str()
+    }
+
+    /// Returns a comma-separated list of package authors.
+    #[must_use]
+    #[inline]
+    pub const fn authors(&self) -> &str {
+        self.authors.as_str()
+    }
+
+    /// Returns a human-friendly title of the package which may be used in some UI displays.
+    #[must_use]
+    #[inline]
+    pub fn title(&self) -> Option<&str> {
+        self.title.as_deref()
+    }
+
+    /// Returns the name of the main executable.
+    #[must_use]
+    #[inline]
+    pub fn main_exe(&self) -> Option<&str> {
+        self.main_exe.as_deref()
+    }
+}


### PR DESCRIPTION
Similar to #1631, I've been using this with Squirrel and its forks for a while.

The exes contain a zip in a resource or the overlay, which contains a nupkg. The nupkg has a spec file with metadata for ARP and DefaultInstallLocation, plus an entrypoint exe that I use to get the architecture