### PR TITLE
Include executable path with portable command alias prompt

### DIFF
--- a/src/analysis/installers/zip.rs
+++ b/src/analysis/installers/zip.rs
@@ -7,7 +7,7 @@ use std::{
 
 use camino::{Utf8Path, Utf8PathBuf};
 use color_eyre::eyre::Result;
-use inquire::{MultiSelect, min_length};
+use inquire::{CustomType, MultiSelect, min_length};
 use tracing::debug;
 use winget_types::installer::{
     Installer, InstallerType, NestedInstallerFiles, PortableCommandAlias,
@@ -15,7 +15,7 @@ use winget_types::installer::{
 use zip::ZipArchive;
 
 use super::super::Analyzer;
-use crate::prompts::{handle_inquire_error, text::optional_prompt};
+use crate::prompts::handle_inquire_error;
 
 const VALID_NESTED_FILE_EXTENSIONS: [&str; 6] =
     ["msix", "msi", "appx", "exe", "msixbundle", "appxbundle"];
@@ -146,7 +146,11 @@ impl<R: Read + Seek> Zip<R> {
                         portable_command_alias: if file_analyzer.installers[0].r#type
                             == Some(InstallerType::Portable)
                         {
-                            optional_prompt::<PortableCommandAlias, &str>(None, None)?
+                            CustomType::<PortableCommandAlias>::new(&format!(
+                                "Portable command alias for {path}:",
+                            ))
+                            .prompt_skippable()
+                            .map_err(handle_inquire_error)?
                         } else {
                             None
                         },


### PR DESCRIPTION
This makes it clear which executable komac is referring to when asking for a `PortableCommandAlias`, especially zips with multiple executables.