### PR TITLE
Use en-US as default locale for `komac new`

### DIFF
--- a/src/commands/new_version.rs
+++ b/src/commands/new_version.rs
@@ -273,7 +273,7 @@ impl NewVersion {
             installers.extend(analyzer_installers);
         }
 
-        let default_locale = required_prompt(self.package_locale, None::<&str>)?;
+        let default_locale = required_prompt(self.package_locale, Some("en-US"))?;
         let mut installer_manifest = InstallerManifest {
             package_identifier: package_identifier.clone(),
             package_version: package_version.clone(),


### PR DESCRIPTION
The majority of manifests use en-US as their default locale so I think this makes sense.