### PR TITLE
Fix installer type for burn bundles with embedded MSI

### DIFF
--- a/src/analysis/installers/burn/mod.rs
+++ b/src/analysis/installers/burn/mod.rs
@@ -139,7 +139,11 @@ impl Burn {
 impl Installers for Burn {
     fn installers(&self) -> Vec<Installer> {
         if let Some(ref msi) = self.msi {
-            return msi.installers();
+            let mut installers = msi.installers();
+            for installer in &mut installers {
+                installer.r#type = Some(InstallerType::Burn);
+            }
+            return installers;
         }
 
         let manifest = self.manifest.as_ref().unwrap_or_else(|| unreachable!());


### PR DESCRIPTION
Fixes installer type being detected as msi for jpackage burn installers.

Examples:
https://github.com/russellbanks/Komac/releases/download/v1.11.0/KomacUserSetup-1.11.0.exe
https://github.com/russellbanks/Komac/releases/download/v1.11.0/KomacMachineSetup-1.11.0.exe
https://github.com/bisq-network/bisq/releases/download/v1.9.22/Bisq-64bit-1.9.22.exe