### PR TITLE
Normalize backslashes in NSIS filesystem paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,6 +2305,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter-highlight",
  "tree-sitter-yaml",
+ "typed-path",
  "url",
  "uuid",
  "walkdir",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ tracing-indicatif = "0.3.14"
 tracing-subscriber = "0.3.23"
 tree-sitter-highlight = "0.26.7"
 tree-sitter-yaml = "0.7.2"
+typed-path = "0.12.3"
 url = { version = "2.5.8", features = ["serde"] }
 uuid = { version = "1.23.0", features = ["v4"] }
 walkdir = "2.5.0"

--- a/src/analysis/installers/nsis/file_system/mod.rs
+++ b/src/analysis/installers/nsis/file_system/mod.rs
@@ -72,6 +72,7 @@ impl FileSystem {
             RelativeLocation::Current => self.current_dir,
         };
 
+        let name = name.as_ref().as_str().replace('\\', "/");
         for component in Self::parse_path(&name) {
             match component {
                 Utf8Component::RootDir => current = self.root,
@@ -120,7 +121,8 @@ impl FileSystem {
         D: Into<Option<DateTime<Utc>>>,
         P: Into<u64>,
     {
-        let path = path.as_ref();
+        let normalized = path.as_ref().as_str().replace('\\', "/");
+        let path = Utf8Path::new(&normalized);
 
         let file_name = path.file_name()?;
 
@@ -154,6 +156,7 @@ impl FileSystem {
             RelativeLocation::Current => self.current_dir,
         };
 
+        let path = path.as_ref().as_str().replace('\\', "/");
         for (position, component) in Self::parse_path(&path).with_position() {
             match component {
                 Utf8Component::RootDir => current = self.root,
@@ -194,7 +197,7 @@ impl FileSystem {
     where
         T: AsRef<str> + Sized,
     {
-        let path = path.as_ref();
+        let path = path.as_ref().replace('\\', "/");
 
         // Return false if the path is empty; it cannot be deleted
         if path.is_empty() {

--- a/src/analysis/installers/nsis/file_system/mod.rs
+++ b/src/analysis/installers/nsis/file_system/mod.rs
@@ -7,12 +7,12 @@ use std::{
     slice::Iter,
 };
 
-use camino::{Utf8Component, Utf8Path};
 use chrono::{DateTime, Utc};
 pub use entry::FsEntry;
 use indextree::{Arena, Node, NodeId};
 use itertools::{Either, Itertools, Position};
 pub use relative_location::RelativeLocation;
+use typed_path::{Utf8Component, Utf8WindowsComponent, Utf8WindowsPath};
 
 use super::{entry::DelFlags, strings::PredefinedVar};
 
@@ -34,9 +34,9 @@ impl FileSystem {
         }
     }
 
-    fn parse_path<'path, T>(path: &'path T) -> impl Iterator<Item = Utf8Component<'path>>
+    fn parse_path<'path, T>(path: &'path T) -> impl Iterator<Item = Utf8WindowsComponent<'path>>
     where
-        T: AsRef<Utf8Path> + 'path,
+        T: AsRef<Utf8WindowsPath> + 'path,
     {
         let path = path.as_ref();
 
@@ -51,7 +51,7 @@ impl FileSystem {
             .next()
             .is_some_and(|component| PredefinedVar::all().iter().contains(component.as_str()))
         {
-            Either::Left(once(Utf8Component::RootDir).chain(components))
+            Either::Left(once(Utf8WindowsComponent::RootDir).chain(components))
         } else {
             Either::Right(components)
         }
@@ -65,23 +65,22 @@ impl FileSystem {
     /// [`set_directory`]: Self::set_directory
     pub fn create_directory<T>(&mut self, name: T, location: RelativeLocation) -> NodeId
     where
-        T: AsRef<Utf8Path>,
+        T: AsRef<Utf8WindowsPath>,
     {
         let mut current = match location {
             RelativeLocation::Root => self.root,
             RelativeLocation::Current => self.current_dir,
         };
 
-        let name = name.as_ref().as_str().replace('\\', "/");
         for component in Self::parse_path(&name) {
             match component {
-                Utf8Component::RootDir => current = self.root,
-                Utf8Component::ParentDir => {
+                Utf8WindowsComponent::RootDir => current = self.root,
+                Utf8WindowsComponent::ParentDir => {
                     if let Some(parent) = current.parent(&self.arena) {
                         current = parent;
                     }
                 }
-                Utf8Component::Normal(part) => {
+                Utf8WindowsComponent::Normal(part) => {
                     if let Some(directory) = current.children(&self.arena).find(|&id| {
                         self.arena
                             .get(id)
@@ -106,7 +105,7 @@ impl FileSystem {
     /// [location]: RelativeLocation
     pub fn set_directory<T>(&mut self, path: T, location: RelativeLocation)
     where
-        T: AsRef<Utf8Path>,
+        T: AsRef<Utf8WindowsPath>,
     {
         self.current_dir = self.create_directory(path, location);
     }
@@ -117,12 +116,11 @@ impl FileSystem {
     /// [datetime]: DateTime<Utc>
     pub fn create_file<T, D, P>(&mut self, path: T, modified_at: D, position: P) -> Option<NodeId>
     where
-        T: AsRef<Utf8Path>,
+        T: AsRef<Utf8WindowsPath>,
         D: Into<Option<DateTime<Utc>>>,
         P: Into<u64>,
     {
-        let normalized = path.as_ref().as_str().replace('\\', "/");
-        let path = Utf8Path::new(&normalized);
+        let path = path.as_ref();
 
         let file_name = path.file_name()?;
 
@@ -149,23 +147,22 @@ impl FileSystem {
     /// [location]: RelativeLocation
     pub fn exists<T>(&self, path: T, location: RelativeLocation) -> bool
     where
-        T: AsRef<Utf8Path>,
+        T: AsRef<Utf8WindowsPath>,
     {
         let mut current = match location {
             RelativeLocation::Root => self.root,
             RelativeLocation::Current => self.current_dir,
         };
 
-        let path = path.as_ref().as_str().replace('\\', "/");
         for (position, component) in Self::parse_path(&path).with_position() {
             match component {
-                Utf8Component::RootDir => current = self.root,
-                Utf8Component::ParentDir => {
+                Utf8WindowsComponent::RootDir => current = self.root,
+                Utf8WindowsComponent::ParentDir => {
                     if let Some(parent) = current.parent(&self.arena) {
                         current = parent;
                     }
                 }
-                Utf8Component::Normal(part) => {
+                Utf8WindowsComponent::Normal(part) => {
                     if let Some(directory) = current.children(&self.arena).find(|&id| {
                         self.arena
                             .get(id)
@@ -197,7 +194,7 @@ impl FileSystem {
     where
         T: AsRef<str> + Sized,
     {
-        let path = path.as_ref().replace('\\', "/");
+        let path = path.as_ref();
 
         // Return false if the path is empty; it cannot be deleted
         if path.is_empty() {
@@ -219,13 +216,13 @@ impl FileSystem {
 
             for component in Self::parse_path(&path) {
                 match component {
-                    Utf8Component::RootDir => current = self.root,
-                    Utf8Component::ParentDir => {
+                    Utf8WindowsComponent::RootDir => current = self.root,
+                    Utf8WindowsComponent::ParentDir => {
                         if let Some(parent) = current.parent(&self.arena) {
                             current = parent;
                         }
                     }
-                    Utf8Component::Normal(part) => {
+                    Utf8WindowsComponent::Normal(part) => {
                         if let Some(child) = current.children(&self.arena).find(|&id| {
                             self.arena
                                 .get(id)

--- a/src/analysis/installers/nsis/mod.rs
+++ b/src/analysis/installers/nsis/mod.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use bzip2::read::BzDecoder;
-use camino::Utf8Path;
+use camino::{Utf8Path, Utf8PathBuf};
 use flate2::{Decompress, read::ZlibDecoder};
 use liblzma::read::XzDecoder;
 use msi::Language;
@@ -25,6 +25,7 @@ use state::NsisState;
 use strsim::levenshtein;
 use thiserror::Error;
 use tracing::{debug, error};
+use typed_path::{Utf8Component, Utf8WindowsPath, Utf8WindowsPathBuf};
 use variables::Variables;
 use winget_types::{
     LanguageTag,
@@ -74,7 +75,7 @@ pub struct Nsis {
     pub is_portable: bool,
     pub registry: Registry,
     pub primary_language_id: u16,
-    pub install_directory: Option<String>,
+    pub install_directory: Option<Utf8WindowsPathBuf>,
 }
 
 impl Nsis {
@@ -169,7 +170,7 @@ impl Nsis {
                 state
                     .variables
                     .install_dir()
-                    .is_some_and(|dir| dir.contains(RELATIVE_PROGRAM_FILES_64))
+                    .is_some_and(|dir| dir.as_str().contains(RELATIVE_PROGRAM_FILES_64))
                     .then_some(Architecture::X64)
             })
             .or_else(|| {
@@ -229,7 +230,10 @@ impl Nsis {
             architecture: architecture.unwrap_or(Architecture::X86),
             is_portable: state.is_portable(),
             registry: state.registry,
-            install_directory: state.variables.install_dir().map(str::to_owned),
+            install_directory: state
+                .variables
+                .install_dir()
+                .map(Utf8WindowsPath::to_path_buf),
             primary_language_id: state.language_table.id(),
         })
     }
@@ -282,7 +286,6 @@ impl Installers for Nsis {
                 default_install_location: self
                     .install_directory
                     .as_deref()
-                    .map(Utf8Path::new)
                     .filter(|path| {
                         !path.components().next().is_none_or(|component| {
                             component
@@ -290,7 +293,7 @@ impl Installers for Nsis {
                                 .eq_ignore_ascii_case(RELATIVE_TEMP_FOLDER)
                         })
                     })
-                    .map(Utf8Path::to_path_buf),
+                    .map(|path| Utf8PathBuf::from(path.as_str())),
                 ..InstallationMetadata::default()
             },
             ..Installer::default()

--- a/src/analysis/installers/nsis/variables.rs
+++ b/src/analysis/installers/nsis/variables.rs
@@ -5,6 +5,8 @@ use std::{
     hash::Hash,
 };
 
+use typed_path::Utf8WindowsPath;
+
 use super::strings::PredefinedVar;
 
 #[derive(Clone)]
@@ -46,9 +48,10 @@ impl<'data> Variables<'data> {
         self.0.remove(index)
     }
 
-    pub fn install_dir(&self) -> Option<&str> {
+    pub fn install_dir(&self) -> Option<&Utf8WindowsPath> {
         self.get(&Self::INSTALL_DIR_INDEX)
             .filter(|&dir| !dir.is_empty())
+            .map(Utf8WindowsPath::new)
     }
 
     pub fn insert_install_dir<T>(&mut self, install_dir: T) -> Option<Cow<'_, str>>


### PR DESCRIPTION
`std::path::Path` (via `camino`) doesn't parse Windows-style paths on Linux or macOS, leading to inaccurate folder trees. `camino` is used elsewhere so adding https://github.com/chipsenkbeil/typed-path felt like dependency bloat. I took a simpler approach, even though I couldn't find a clean way like normalising in `parse_path`. Maybe a separate helper function would be better?

Tested with `AltSnap.AltSnap`, [diff](https://diffviewer.vercel.app/v2/diff#H4sIAAAAAAAAA62V0W7aMBRAfyWK1Lc1e4_UB1ZgaosCIkHTJEsXEwzxcBwUexLttn9fKAn1vTZ7Gk9wjrmJRY75FavKxGk8nnxZfY0OTc3LNOWaq1cjTZpKbSxXSrTde30mUffZimQnlQDzaqyoHz6zlunf9_fR3eh4HHPL7xgbKZtrfmTs3UVRdPY9TLZahrA4iRC2JxvCp1q5uGqag0m2CsGZLIU2go4wZQVznWz4la4Huttd8a0NsRnXe3ccCA2rPNpwI5TU3tVKDpM8kXjPWwHjCYXCBFbuJEyfPNjCdEnhXgW-Li08FRT-4PC8oPDQwIs3U28gm3tQQTaj8Khg4UMLC29m-xOWKwrNG-QvFL5V8Ji5cH2BxbcBrm_-SkUlamEYEy03tWz0eXXUzy2Wo-8wn04TWTY-z1y8HnC-ys88_hS3_yUYfOfO1YY99Gi4NxJPSPUBhVT_TIZUH5KrUEyuIEG5CkflmY-w0Lw-pSv7d1J0GUqLSpQYlSg1KlFynnTToxIlSCVKkUqUJJUoTSpRop50U6USJetJN10qUcJUopSpREm70kt7kO8FXmJ26GBo3u7rVurhNdmtJYEjoPvPnPGNUN05MG_lXnb5R4U42cvpMKjHqnu8xfZi_vwFzCoMEmoHAAA)