### PR TITLE
Write NSIS shortcuts to filesystem

### DIFF
--- a/src/analysis/installers/nsis/entry/mod.rs
+++ b/src/analysis/installers/nsis/entry/mod.rs
@@ -657,9 +657,12 @@ impl Entry {
                     debug!(r#"ExtractFile: "{name}" {date}"#);
                     Some(date)
                 };
-                state
-                    .file_system
-                    .create_file(&*name, date, position.get().unsigned_abs());
+                state.file_system.create_file(
+                    &*name,
+                    date,
+                    position.get().unsigned_abs(),
+                    RelativeLocation::Current,
+                );
             }
             Self::DeleteFile { filename, flags } => {
                 let filename = state.get_string(filename.get());
@@ -1095,6 +1098,9 @@ impl Entry {
                         ""
                     },
                 );
+                state
+                    .file_system
+                    .create_file(&*link_file, None, 0u64, RelativeLocation::Root);
             }
             Self::CopyFiles {
                 source_mask,
@@ -1369,9 +1375,12 @@ impl Entry {
                     state.get_string(alternative_path.get())
                 };
                 debug!(r#"WriteUninstaller: "{name}""#);
-                state
-                    .file_system
-                    .create_file(&*name, None, offset.get().unsigned_abs());
+                state.file_system.create_file(
+                    &*name,
+                    None,
+                    offset.get().unsigned_abs(),
+                    RelativeLocation::Current,
+                );
             }
             Self::SectionSet {
                 index,

--- a/src/analysis/installers/nsis/file_system/mod.rs
+++ b/src/analysis/installers/nsis/file_system/mod.rs
@@ -114,7 +114,13 @@ impl FileSystem {
     /// [datetime], and a position.
     ///
     /// [datetime]: DateTime<Utc>
-    pub fn create_file<T, D, P>(&mut self, path: T, modified_at: D, position: P) -> Option<NodeId>
+    pub fn create_file<T, D, P>(
+        &mut self,
+        path: T,
+        modified_at: D,
+        position: P,
+        location: RelativeLocation,
+    ) -> Option<NodeId>
     where
         T: AsRef<Utf8Path>,
         D: Into<Option<DateTime<Utc>>>,
@@ -125,9 +131,12 @@ impl FileSystem {
         let file_name = path.file_name()?;
 
         let directory = if let Some(parent) = path.parent() {
-            self.create_directory(parent, RelativeLocation::Current)
+            self.create_directory(parent, location)
         } else {
-            self.current_dir
+            match location {
+                RelativeLocation::Root => self.root,
+                RelativeLocation::Current => self.current_dir,
+            }
         };
 
         if let Some(file) = directory.children(&self.arena).find(|&id| {


### PR DESCRIPTION
Examples below, but they're better with #1700

```
`-- SMPrograms\AltSnap.lnk
```

or 

```
SMPrograms\Disk Sorter\Disk Sorter.lnk
|-- SMPrograms\Disk Sorter\License.lnk
`-- SMPrograms\Disk Sorter\Uninstall.lnk
```