### PR TITLE
Handle NSIS uninstaller path variables and reset working dir for each section

### DIFF
--- a/src/analysis/installers/nsis/entry/mod.rs
+++ b/src/analysis/installers/nsis/entry/mod.rs
@@ -1357,6 +1357,7 @@ impl Entry {
                     if let Some((&first, &second)) = path.first().zip(path.get(1)) {
                         (first == b'\\' && second == b'\\')
                             || (first.is_ascii_alphabetic() && second == b':')
+                            || (first == b'%')
                     } else {
                         false
                     }

--- a/src/analysis/installers/nsis/entry/mod.rs
+++ b/src/analysis/installers/nsis/entry/mod.rs
@@ -1357,7 +1357,7 @@ impl Entry {
                     if let Some((&first, &second)) = path.first().zip(path.get(1)) {
                         (first == b'\\' && second == b'\\')
                             || (first.is_ascii_alphabetic() && second == b':')
-                            || (first == b'%')
+                            || first == b'%'
                     } else {
                         false
                     }

--- a/src/analysis/installers/nsis/file_system/mod.rs
+++ b/src/analysis/installers/nsis/file_system/mod.rs
@@ -99,6 +99,12 @@ impl FileSystem {
         current
     }
 
+    /// Sets the current directory to the root.
+    #[inline]
+    pub const fn set_root(&mut self) {
+        self.current_dir = self.root;
+    }
+
     /// Sets the current directory from a path, relative to a [location], creating it and all
     /// necessary parent directories if they do not already exist.
     ///

--- a/src/analysis/installers/nsis/state.rs
+++ b/src/analysis/installers/nsis/state.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::analysis::installers::nsis::{
     NsisError,
-    file_system::FileSystem,
+    file_system::{FileSystem, RelativeLocation},
     header::{
         Header,
         block::{BlockHeaders, BlockType},
@@ -223,6 +223,9 @@ impl<'data> NsisState<'data> {
     ///
     /// <https://github.com/NSIS-Dev/nsis/blob/v311/Source/exehead/exec.c#L79>
     pub fn execute_code_segment(&mut self, mut position: i32) -> Result<Entry, EntryError> {
+        // Reset file system directory to root
+        self.file_system.set_directory("", RelativeLocation::Root);
+
         // Create a watchdog counter to detect infinite loops
         let mut watchdog_counter = 0;
 

--- a/src/analysis/installers/nsis/state.rs
+++ b/src/analysis/installers/nsis/state.rs
@@ -11,7 +11,7 @@ use super::{
 };
 use crate::analysis::installers::nsis::{
     NsisError,
-    file_system::{FileSystem, RelativeLocation},
+    file_system::FileSystem,
     header::{
         Header,
         block::{BlockHeaders, BlockType},
@@ -224,7 +224,7 @@ impl<'data> NsisState<'data> {
     /// <https://github.com/NSIS-Dev/nsis/blob/v311/Source/exehead/exec.c#L79>
     pub fn execute_code_segment(&mut self, mut position: i32) -> Result<Entry, EntryError> {
         // Reset file system directory to root
-        self.file_system.set_directory("", RelativeLocation::Root);
+        self.file_system.set_root();
 
         // Create a watchdog counter to detect infinite loops
         let mut watchdog_counter = 0;


### PR DESCRIPTION
Variables like `%ProgramFiles%` are always substituted with an absolute path like `C:\...`, so we should treat them as absolute

Tested with `Flexense.DiskSorter`. I also noticed while testing that new sections expect the filesystem working directory to be at the root, not copied from the previous section

Before:

```
DEBUG {439}: komac::analysis::installers::nsis::entry: WriteUninstaller: "%ProgramFiles%\Disk Sorter\%ProgramFiles%\Disk Sorter\uninstall.exe"
DEBUG {440}: komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis: state.file_system=/
|-- %ProgramFiles%\Disk Sorter\bin
|   |-- disksr.ico
|   |-- libpal.dll
|   |-- libspp.dll
|   |-- sppinst.exe
|   |-- Microsoft.VC80.CRT.manifest
|   |-- msvcr80.dll
|   |-- QtCore4.dll
|   |-- QtGui4.dll
|   |-- libspg.dll
|   |-- libdsr.dll
|   |-- libdsrg.dll
|   |-- disksr.exe
|   |-- sppshex.exe
|   |-- disksorter.flx
|   |-- Plugins\AccessControl.dll
|   |-- SMPrograms\Disk Sorter
|   `-- %ProgramFiles%\Disk Sorter\%ProgramFiles%\Disk Sorter\uninstall.exe
```

After:
```
DEBUG {439}: komac::analysis::installers::nsis::entry: WriteUninstaller: "%ProgramFiles%\Disk Sorter\uninstall.exe"
DEBUG {440}: komac::analysis::installers::nsis::entry: Return
DEBUG komac::analysis::installers::nsis: state.file_system=/
<snip>
-- %ProgramFiles%\Disk Sorter\uninstall.exe
```