### PR TITLE
Normalize MSI `DefaultInstallLocation`

### DIFF
--- a/src/analysis/installers/msi/mod.rs
+++ b/src/analysis/installers/msi/mod.rs
@@ -19,7 +19,7 @@ use winget_types::{
 
 use crate::{
     analysis::{installers::msi::directory_table::DirectoryTable, r#trait::Installers},
-    traits::AsciiExt,
+    traits::{AsciiExt, path::NormalizePath},
 };
 
 const PROPERTY: &str = "Property";
@@ -154,6 +154,7 @@ impl Msi {
                 }
                 Option::from(path).filter(|path| !path.as_str().is_empty())
             })
+            .map(|directory| directory.normalize())
     }
 
     /// Returns the actual `ProductVersion` for Google Chrome.


### PR DESCRIPTION
Collapses any current directory references in  `DefaultInstallLocation` for MSI installers.

Examples: https://github.com/search?q=repo%3Amicrosoft%2Fwinget-pkgs+%2FDefaultInstallLocation%3A.*(\%2F.\%2F|\\\.\\).*%2F+path%3Amanifests+language%3Ayaml&type=code