### PR TITLE
Hide GITHUB_TOKEN values from clap's help texts

### DIFF
--- a/src/commands/cleanup.rs
+++ b/src/commands/cleanup.rs
@@ -33,7 +33,7 @@ pub struct Cleanup {
     all: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/list_versions.rs
+++ b/src/commands/list_versions.rs
@@ -23,7 +23,7 @@ pub struct ListVersions {
     count: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/new_version.rs
+++ b/src/commands/new_version.rs
@@ -149,7 +149,7 @@ pub struct NewVersion {
     skip_pr_check: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/remove_dead_versions.rs
+++ b/src/commands/remove_dead_versions.rs
@@ -57,7 +57,7 @@ pub struct RemoveDeadVersions {
     concurrent: NonZeroUsize,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/remove_version.rs
+++ b/src/commands/remove_version.rs
@@ -51,7 +51,7 @@ pub struct RemoveVersion {
     open_pr: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/show_version.rs
+++ b/src/commands/show_version.rs
@@ -34,7 +34,7 @@ pub struct ShowVersion {
     version_manifest: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -52,7 +52,7 @@ pub struct Submit {
     dry_run: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/sync_fork.rs
+++ b/src/commands/sync_fork.rs
@@ -28,7 +28,7 @@ pub struct SyncFork {
     force: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/commands/update_version.rs
+++ b/src/commands/update_version.rs
@@ -102,7 +102,7 @@ pub struct UpdateVersion {
     skip_pr_check: bool,
 
     /// GitHub personal access token with the `public_repo` scope
-    #[arg(short, long, env = "GITHUB_TOKEN")]
+    #[arg(short, long, env = "GITHUB_TOKEN", hide_env_values = true)]
     token: Option<SecretString>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,3 +114,33 @@ enum Commands {
     RemoveDeadVersions(RemoveDeadVersions),
     Submit(Submit),
 }
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::Cli;
+
+    #[test]
+    fn github_token_env_values_are_hidden_in_help() {
+        fn assert_github_token_env_is_hidden(command: &clap::Command) {
+            for arg in command.get_arguments() {
+                if arg.get_env() == Some(std::ffi::OsStr::new("GITHUB_TOKEN")) {
+                    assert!(
+                        arg.is_hide_env_values_set(),
+                        "command `{}` arg `{:?}` exposes GITHUB_TOKEN values in help",
+                        command.get_name(),
+                        arg.get_id()
+                    );
+                }
+            }
+
+            for subcommand in command.get_subcommands() {
+                assert_github_token_env_is_hidden(subcommand);
+            }
+        }
+
+        let command = Cli::command();
+        assert_github_token_env_is_hidden(&command);
+    }
+}


### PR DESCRIPTION
Previously, clap was printing GitHub tokens that were passed in via the OS environment.

Fixes #1752.