### PR TITLE
Stop overriding previous license with GitHub value

### DIFF
--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -219,17 +219,10 @@ impl LocaleExt for DefaultLocaleManifest {
                 .as_ref()
                 .map(|values| values.package_url.clone());
         }
-        if let Some(github_license) = github_values
-            .as_mut()
-            .and_then(|values| values.license.take())
-        {
-            self.license = github_license;
-        }
-        if let Some(github_license_url) = github_values
-            .as_mut()
-            .and_then(|values| values.license_url.take())
-        {
-            self.license_url = Some(github_license_url);
+        if self.license_url.is_none() {
+            self.license_url = github_values
+                .as_mut()
+                .and_then(|values| values.license_url.take())
         }
         if self.tags.is_empty() {
             self.tags = github_values


### PR DESCRIPTION
Overriding the license in the previous manifest with the one from the release's GitHub repository can sometimes add an incorrect license to the manifest. For example, if the repository containing the release has a different license than actual program/repo. This can also replace a more specific license with a less specific one. For example, `GPL-3.0-or-later` and `GPL-3.0-only` with `GPL-3.0` or `OFL-1.1-RFN` and `OFL-1.1-no-RFN` with `OFL-1.1`.