### PR TITLE
Fix new package PR title prefix for komac submit

### DIFF
--- a/src/commands/submit.rs
+++ b/src/commands/submit.rs
@@ -166,7 +166,7 @@ impl Submit {
                 continue;
             }
 
-            let versions = github.get_versions(identifier).await.unwrap_or_default();
+            let versions = github.get_versions(identifier).await.ok();
 
             rate_limit.wait().await;
 
@@ -180,7 +180,7 @@ impl Submit {
                 .add_version()
                 .identifier(identifier)
                 .version(version)
-                .versions(&versions)
+                .maybe_versions(versions.as_ref())
                 .changes(changes)
                 .issue_resolves(&self.resolves)
                 .send()


### PR DESCRIPTION
This preserves a missing package lookup as `None` instead of converting it to an empty version set so `UpdateState::get` correctly uses the 'New package:' prefix instead of 'Add version:' for new package PRs.