### PR TITLE
Autofill `InstallLocation` for WiX installers

### DIFF
--- a/src/analysis/installers/msi/mod.rs
+++ b/src/analysis/installers/msi/mod.rs
@@ -229,13 +229,18 @@ impl Msi {
     }
 
     fn install_location_switches(&self) -> InstallerSwitches {
-        if let Some(install_dir) = self.wix_ui_install_dir() {
-            return InstallerSwitches::builder()
-                .install_location(format!(r#"{install_dir}="<INSTALLPATH>""#).parse().unwrap())
-                .build();
-        }
-
-        InstallerSwitches::default()
+        self.wix_ui_install_dir()
+            .and_then(|install_dir| {
+                format!(r#"{install_dir}="<INSTALLPATH>""#)
+                    .parse()
+                    .map(|switch| {
+                        InstallerSwitches::builder()
+                            .install_location(switch)
+                            .build()
+                    })
+                    .ok()
+            })
+            .unwrap_or_default()
     }
 
     fn is_wix(&self) -> bool {

--- a/src/analysis/installers/msi/mod.rs
+++ b/src/analysis/installers/msi/mod.rs
@@ -13,7 +13,7 @@ use winget_types::{
     LanguageTag,
     installer::{
         AppsAndFeaturesEntries, AppsAndFeaturesEntry, Architecture, InstallationMetadata,
-        Installer, InstallerType, Scope,
+        Installer, InstallerSwitches, InstallerType, Scope,
     },
 };
 
@@ -106,11 +106,8 @@ impl Msi {
         self.build_directory(INSTALL_DIR, TARGET_DIR)
             .or_else(|| {
                 // Check the value of the `WIXUI_INSTALLDIR` property
-                const WIX_UI_INSTALL_DIR: &str = "WIXUI_INSTALLDIR";
-
-                self.property_table
-                    .get(WIX_UI_INSTALL_DIR)
-                    .and_then(|wix_install_dir| self.build_directory(wix_install_dir, TARGET_DIR))
+                self.wix_ui_install_dir()
+                    .and_then(|install_dir| self.build_directory(install_dir, TARGET_DIR))
             })
             .or_else(|| {
                 // Check for an `INSTALLLOCATION` directory entry
@@ -225,6 +222,22 @@ impl Msi {
             .ok()
     }
 
+    fn wix_ui_install_dir(&self) -> Option<&str> {
+        const WIX_UI_INSTALL_DIR: &str = "WIXUI_INSTALLDIR";
+
+        self.property_table.get(WIX_UI_INSTALL_DIR)
+    }
+
+    fn install_location_switches(&self) -> InstallerSwitches {
+        if let Some(install_dir) = self.wix_ui_install_dir() {
+            return InstallerSwitches::builder()
+                .install_location(format!(r#"{install_dir}="<INSTALLPATH>""#).parse().unwrap())
+                .build();
+        }
+
+        InstallerSwitches::default()
+    }
+
     fn is_wix(&self) -> bool {
         const WIX: &str = "Wix";
         const WINDOWS_INSTALLER_XML: &str = "Windows Installer XML";
@@ -260,6 +273,7 @@ impl Installers for Msi {
                 InstallerType::Msi
             }),
             scope: self.find_scope(),
+            switches: self.install_location_switches(),
             product_code: product_code.map(str::to_owned),
             apps_and_features_entries: if product_name.is_some()
                 || manufacturer.is_some()


### PR DESCRIPTION
The `WIXUI_INSTALLDIR` property can be used to autofill `InstallLocation` switches in the manifest.