### PR TITLE
Update GitHub REST API to 2026-03-10

### DIFF
--- a/src/github/rest/mod.rs
+++ b/src/github/rest/mod.rs
@@ -11,4 +11,4 @@ pub const X_GITHUB_API_VERSION: HeaderName = HeaderName::from_static("x-github-a
 
 pub const REST_API_URL: &str = "https://api.github.com";
 
-pub const REST_API_VERSION: HeaderValue = HeaderValue::from_static("2022-11-28");
+pub const REST_API_VERSION: HeaderValue = HeaderValue::from_static("2026-03-10");


### PR DESCRIPTION
REST API version 2022-11-28 will be [unsupported ](https://docs.github.com/en/rest/about-the-rest-api/api-versions?apiVersion=2026-03-10#supported-api-versions)on March 10, 2028. The latest version shouldn't have any breaking changes that affect komac.

Breaking changes: https://docs.github.com/en/rest/about-the-rest-api/breaking-changes?apiVersion=2026-03-10#version-2026-03-10